### PR TITLE
Update Vagrantfile to eliminate double ssh ports

### DIFF
--- a/lib/yeoman/templates/Vagrantfile
+++ b/lib/yeoman/templates/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
 
     # Static IP for testing.
     box.vm.network :private_network, ip: "<%= props.ip %>"
-    box.vm.network :forwarded_port, guest: 22, host: <%= props.ip.split('.').join('').split('0').join('').slice(-4) %>, auto_correct: true
+    box.vm.network :forwarded_port, guest: 22, id: 'ssh', host: <%= props.ip.split('.').join('').split('0').join('').slice(-4) %>, auto_correct: true
 
     box.ssh.forward_agent = true
 


### PR DESCRIPTION
Vagrant shares port 2222 with our custom port, even though we do not tell it to.
Adding the `id: ssh` resolves that.
Goes from this:

```
==> local: Forwarding ports...
    local: 22 => 2238 (adapter 1)
    local: 22 => 2222 (adapter 1)
```

to this:

```
==> local: Forwarding ports...
    local: 22 => 2238 (adapter 1)
```
