### PR TITLE
SSL bugfixes abound

### DIFF
--- a/lib/ansible/roles/pound/tasks/main.yml
+++ b/lib/ansible/roles/pound/tasks/main.yml
@@ -26,3 +26,20 @@
   lineinfile: regexp='^startup=0' line='startup=1' dest=/etc/default/pound backup=yes
   notify:     restart pound
   sudo:       yes
+
+- name:       Configure HTTPS Forwarded Proto detection in Apache (2.2)
+  copy:       content="SetEnvIf X-Forwarded-Proto ^https$ HTTPS=on\n" dest=/etc/apache2/conf.d/https-forwarded-proto.conf mode=0644
+  notify:     restart apache
+  when:       apache_version.stdout == '2.2'
+  sudo:       true
+
+- name:       Configure HTTPS Forwarded Proto detection in Apache (2.4)
+  copy:       content="SetEnvIf X-Forwarded-Proto ^https$ HTTPS=on\n" dest=/etc/apache2/conf-available/https-forwarded-proto.conf mode=0644
+  when:       apache_version.stdout == '2.4'
+  sudo:       true
+
+- name:       Enable canonical config (2.4)
+  command:    a2enconf https-forwarded-proto
+  notify:     restart apache
+  when:       apache_version.stdout == '2.4'
+  sudo:       yes

--- a/lib/ansible/roles/pound/templates/pound.cfg
+++ b/lib/ansible/roles/pound/templates/pound.cfg
@@ -35,11 +35,18 @@ ListenHTTPS
   Address 0.0.0.0
   Port    443
 
+  HeadRemove "X-Forwarded-Proto"
+  AddHeader  "X-Forwarded-Proto: https"
+
 {% for cert in ['production','staging','local'] %}
   Cert    "/etc/pound/{{ cert }}.{{ domain }}.pem"
 
   Service
-    HeadRequire "Host: .*{{ cert }}.{{ domain }}.*"
+{% if cert == 'production' %}
+    HeadRequire "Host: .*((www|{{ cert }})\.)?{{ domain|replace('.','\\.') }}.*"
+{% else %}
+    HeadRequire "Host: .*{{ cert }}\.{{ domain|replace('.','\\.') }}.*"
+{% endif %}
     BackEnd
       Address 127.0.0.1
       Port  80

--- a/lib/ansible/roles/varnish/files/etc-varnish/production.vcl
+++ b/lib/ansible/roles/varnish/files/etc-varnish/production.vcl
@@ -179,6 +179,11 @@ sub vcl_hash {
         hash_data(req.http.Authorization);
     }
 
+    # hash forwarded protocol, if present
+    if (req.http.X-Forwarded-Proto) {
+        hash_data(req.http.X-Forwarded-Proto);
+    }
+
     return (hash);
 }
 

--- a/test/functional/wordpress/07-sni.js
+++ b/test/functional/wordpress/07-sni.js
@@ -2,6 +2,7 @@
 
 var assert  = require('assert');
 var exec    = require('child_process').exec;
+var Browser = require('zombie');
 
 describe('ssl server name indication', function(done) {
   it('local host should serve local cert', function(done) {
@@ -15,7 +16,29 @@ describe('ssl server name indication', function(done) {
     });
   });
 
-  it('production host should serve production cert', function(done) {
+  it('production.domain (1/3) should serve production cert', function(done) {
+    this.timeout(60 * 1000);
+
+    exec('openssl s_client -connect production.example.com:443 -servername production.example.com', {
+      cwd: process.cwd() + '/temp'
+    }, function(err, stdout, stderr) {
+      assert.ifError(! stdout.match('CN=example.com'));
+      done();
+    });
+  });
+
+  it('www.domain (2/3) should serve production cert', function(done) {
+    this.timeout(60 * 1000);
+
+    exec('openssl s_client -connect www.example.com:443 -servername www.example.com', {
+      cwd: process.cwd() + '/temp'
+    }, function(err, stdout, stderr) {
+      assert.ifError(! stdout.match('CN=example.com'));
+      done();
+    });
+  });
+
+  it('bare domain (3/3) should serve production cert', function(done) {
     this.timeout(60 * 1000);
 
     exec('openssl s_client -connect production.example.com:443 -servername production.example.com', {


### PR DESCRIPTION
This was a tricky one to unravel, as it involved several layers of the environment.

* Pound now adds `X-Forwarded-Proto` header to indicate proxied SSL
* Pound now correctly handles ssl for `www.{{domain}}` and `{{domain}}`, in addition to `production.{{domain}}`
* Varnish now correctly hashes on `X-Forwarded-Proto`, so HTTP and HTTPS traffic won't conflict with each other's caches
* Apache now sets `HTTPS=on` on `X-Forwarded-Proto` header, thus getting Wordpress to serve https links!