### PR TITLE
Added New Relic monitoring

### DIFF
--- a/lib/ansible/roles/newrelic/handlers/main.yml
+++ b/lib/ansible/roles/newrelic/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name:     restart newrelic-sysmond
+  service:  name=newrelic-sysmond state=restarted
+  sudo:     true

--- a/lib/ansible/roles/newrelic/tasks/main.yml
+++ b/lib/ansible/roles/newrelic/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name:           Install repository key
+  apt_key:        url=https://download.newrelic.com/548C16BF.gpg state=present
+  sudo:           yes
+
+- name:           Configure repository source list
+  apt_repository: repo='deb http://apt.newrelic.com/debian/ newrelic non-free' state=present
+  sudo:           yes
+
+- name:           Install PHP agent and sys monitor
+  apt:            name={{ item }} state=latest update_cache=yes
+  sudo:           yes
+  with_items:
+    - newrelic-php5
+    - newrelic-sysmond
+
+- name:           Configure PHP agent license key and app name
+  lineinfile:     dest={{ php_conf.stdout }}/newrelic.ini regexp="^{{ item.key }}" line="{{ item.key }} = '{{ item.value }}'"
+  sudo:           yes
+  with_dict:
+    newrelic.appname: "{{ domain }} ({{ stage }})"
+    newrelic.license: "{{ monitoring.newrelic }}"
+  notify:         restart apache
+
+- name:           Configure and start sys monitor
+  command:        nrsysmond-config --set license_key={{ monitoring.newrelic }}
+  sudo:           yes
+  notify:         restart newrelic-sysmond

--- a/lib/ansible/roles/php/tasks/main.yml
+++ b/lib/ansible/roles/php/tasks/main.yml
@@ -4,14 +4,20 @@
   with_items:     php_packages
   sudo:           yes
 
+- shell:          ls -1d /etc/php5/conf.d 2>/dev/null || ls -1d /etc/php5/mods-available
+  register:       php_conf
+  sudo:           yes
+
+- debug:          var={{ php_conf.stdout }}
+
 - name:           Install PECL packages
-  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates=/etc/php5/conf.d/{{ item if item is string else item.name }}.ini
+  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php_conf.stdout }}/{{ item if item is string else item.name }}.ini
   with_items:     pecl_packages
   sudo:           yes
 
 - name:           Enable PECL packages
   lineinfile:     line="extension={{ item if item is string else item.name }}.so"
-                  dest="/etc/php5/conf.d/{{ item if item is string else item.name }}.ini"
+                  dest="{{ php_conf.stdout }}/{{ item if item is string else item.name }}.ini"
                   create=yes
   with_items:     pecl_packages
   sudo:           yes

--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -256,6 +256,27 @@ var WordpressGenerator = yeoman.generators.Base.extend({
     });
   },
 
+  promptForNewrelic: function() {
+    var existing = function() {
+      try {
+        var match = this.readFileAsString(path.join(this.env.cwd, 'lib', 'ansible', 'group_vars', 'all'))
+          .match(/newrelic[ ]*:[ ]*(?:'|")?([^'"\s]+)/i);
+
+        return match[1];
+      } catch(e) {};
+    }.bind(this);
+
+    this.prompts.push({
+      required: true,
+      type:     'text',
+      name:     'newrelic',
+      message:  'New Relic license key (leave blank to disable)',
+      default:  function () {
+        return existing() || '';
+      }.bind(this)
+    });
+  },
+
   promptForRoles: function() {
     try {
       var provisionYml = this.readFileAsString(path.join(this.env.cwd, 'lib', 'ansible', 'provision.yml'));

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -3,6 +3,9 @@ evolve_version: <%= pkg.version %>
 domain:         <%= props.domain %>
 www:            <%= props.www %>
 
+monitoring:
+  newrelic:     '<%= props.newrelic %>'
+
 mysql:
   name:         <%= props.DB_NAME %>
   user:         <%= props.DB_USER %>

--- a/lib/yeoman/templates/lib/ansible/provision.yml
+++ b/lib/yeoman/templates/lib/ansible/provision.yml
@@ -16,6 +16,7 @@
     # Optional Features
     <% if (props.ssl) { %>- pound             # (Optional) SSL support & decryption<% } %><% props.roles.map(function(role) { %>
     <%= role.checked ? '-' : '#' %> <%= role.value %><% }) %>
-    # /Optional Features
+<% if (props.newrelic) { %>    - newrelic          # (Optional) New Relic application/server monitoring
+<% } %>    # /Optional Features
 
     - cleanup           # (Required) Generate init.d for installed evolution services


### PR DESCRIPTION
Adds a generator prompt for New Relic license key (skipped if blank), and a role for installing the PHP agent and server monitor daemon.

Fixes #50 