### PR TITLE
Handle two digit wordpress versions

### DIFF
--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -708,28 +708,26 @@ WordpressGenerator.latest = function(username, repo, fn) {
           var ma = a.match(fuzzyver);
           var mb = b.match(fuzzyver);
 
-          if (ma && mb) {
-            if (ma[1] == mb[1]) {
-              if (ma[2] == mb[2]) {
-                ma[3] = ma[3] || '0';
-                mb[3] = mb[3] || '0';
-                if (ma[3] == mb[3])
-                  return 0;
-                else if (parseInt(ma[3]) > parseInt(mb[3]))
-                  return 1;
-                else
-                  return -1;
-              }
-              else if (parseInt(ma[2]) > parseInt(mb[2]))
+          if (ma[1] == mb[1]) {
+            if (ma[2] == mb[2]) {
+              ma[3] = ma[3] || '0';
+              mb[3] = mb[3] || '0';
+              if (ma[3] == mb[3])
+                return 0;
+              else if (parseInt(ma[3]) > parseInt(mb[3]))
                 return 1;
               else
                 return -1;
             }
-            else if (parseInt(ma[1]) > parseInt(mb[1]))
+            else if (parseInt(ma[2]) > parseInt(mb[2]))
               return 1;
             else
               return -1;
           }
+          else if (parseInt(ma[1]) > parseInt(mb[1]))
+            return 1;
+          else
+            return -1;
         });
     } catch (e) {
       return fn(e);

--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -6,7 +6,6 @@ var fs      = require('fs-extra');
 var glob    = require('glob');
 var path    = require('path');
 var keygen  = require('ssh-keygen');
-var latest  = require('github-latest');
 var request = require('request');
 var yeoman  = require('yeoman-generator');
 var util    = require('util');
@@ -292,13 +291,13 @@ var WordpressGenerator = yeoman.generators.Base.extend({
 
     var done = this.async();
 
-    latest('wordpress', 'wordpress', function(err, tag) {
+    WordpressGenerator.latest('wordpress', 'wordpress', function(err, tag) {
       this.prompts.push({
         type:     'text',
         name:     'wordpress',
         message:  'WordPress version',
         default:  function() {
-          return existing() || tag || '4.1.3';
+          return existing() || tag || '4.2';
         }
       });
 
@@ -689,5 +688,55 @@ WordpressGenerator.roles = [
     checked:  true,
   },
 ];
+
+WordpressGenerator.latest = function(username, repo, fn) {
+  request({
+    url: 'https://api.github.com/repos/' + username + '/' + repo + '/git/refs/tags/',
+    headers: { 'user-agent': 'https://github.com/request/request' }
+  }, function (err, res, body) {
+    if(!(/^200/).test(res.headers.status))
+      return fn(new Error(res.headers.status));
+
+    try {
+      var fuzzyver = /^\s*v?(\d+)\.(\d+)(?:\.(\d+))?\s*$/;
+      var tags = JSON.parse(body)
+        .map(function(item){
+          return item.ref.split('/').pop();
+        })
+        .filter(RegExp.prototype.test.bind(fuzzyver))
+        .sort(function (a, b) {
+          var ma = a.match(fuzzyver);
+          var mb = b.match(fuzzyver);
+
+          if (ma && mb) {
+            if (ma[1] == mb[1]) {
+              if (ma[2] == mb[2]) {
+                ma[3] = ma[3] || '0';
+                mb[3] = mb[3] || '0';
+                if (ma[3] == mb[3])
+                  return 0;
+                else if (parseInt(ma[3]) > parseInt(mb[3]))
+                  return 1;
+                else
+                  return -1;
+              }
+              else if (parseInt(ma[2]) > parseInt(mb[2]))
+                return 1;
+              else
+                return -1;
+            }
+            else if (parseInt(ma[1]) > parseInt(mb[1]))
+              return 1;
+            else
+              return -1;
+          }
+        });
+    } catch (e) {
+      return fn(e);
+    }
+
+    fn(null, tags.pop());
+  });
+};
 
 module.exports = WordpressGenerator;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "fs-extra": "^0.11.1",
-    "github-latest": "^0.1.2",
     "request": "^2.42.0",
     "ssh-keygen": "^0.2.1",
     "in-words": "^0.1.0",


### PR DESCRIPTION
Replaces [github-latest](https://github.com/tmpvar/github-latest), which excludes two digit non-semantic versions like `4.2`, with small reimplementation.

It's a little ugly, but it works :neckbeard: 

Fixes #26 