### PR TITLE
Open branch subdomain in browser?

### DIFF
--- a/lib/yeoman/templates/lib/capistrano/deploy.rb
+++ b/lib/yeoman/templates/lib/capistrano/deploy.rb
@@ -26,8 +26,8 @@ namespace :deploy do
   after :finished, :launch_browser do
     require 'launchy'
 
-    subdomain = fetch(:stage)
-    branch = fetch(:branch)
+    subdomain = fetch(:stage).to_s
+    branch = fetch(:branch).to_s
 
     if subdomain == 'staging' && branch != 'master'
       subdomain = "#{branch}.staging"

--- a/lib/yeoman/templates/lib/capistrano/deploy.rb
+++ b/lib/yeoman/templates/lib/capistrano/deploy.rb
@@ -25,7 +25,15 @@ namespace :deploy do
   end
   after :finished, :launch_browser do
     require 'launchy'
-    uri = "http://#{fetch(:stage)}.#{fetch(:domain)}/"
+
+    subdomain = fetch(:stage)
+    branch = fetch(:branch)
+
+    if subdomain == 'staging' && branch != 'master'
+      subdomain = "#{branch}.staging"
+    end
+
+    uri = "http://#{subdomain}.#{fetch(:domain)}/"
     Launchy.open(uri) do |exception|
       puts "Failed to open #{uri} because #{exception}"
     end


### PR DESCRIPTION
When doing a `staging deploy` and the branch is something other than `master`, we should open `{branch}.staging.{domain}` instead of just `staging.{domain}`