### PR TITLE
Vagrant requires vagrant user password on any vm interaction

### DIFF
--- a/lib/yeoman/templates/Vagrantfile
+++ b/lib/yeoman/templates/Vagrantfile
@@ -7,7 +7,6 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box         = "ubuntu/trusty64"
-  config.ssh.insert_key = false
 
   # Configure 1GB (1024MB) of memory
   config.vm.provider :virtualbox do |vb|
@@ -22,13 +21,8 @@ Vagrant.configure("2") do |config|
     box.vm.network :private_network, ip: "<%= props.ip %>"
     box.vm.network :forwarded_port, guest: 22, id: 'ssh', host: <%= props.ip.split('.').join('').split('0').join('').slice(-4) %>, auto_correct: true
 
-    box.ssh.forward_agent = true
-
     # Remount the default shared folder as NFS for caching and speed
     box.vm.synced_folder ".", "/vagrant", :nfs => true
-
-    # Mount local SSH keys for deployments
-    box.vm.synced_folder "~/.ssh", "/home/vagrant/.ssh"
 
     # Provision local.<%= props.domain %>
     box.vm.provision :ansible do |ansible|


### PR DESCRIPTION
Installed evolve wp 1.0.15 and wp 4.2.2 on osx with vagrant 1.7.2

Perhaps there is something I'm not doing with passwords/keys that I should be.
All new provisions of evolve require a vagrant password when interacting with the vm. Whether shell or not for instance, ```vagrant reload``` asks for password before allowing : 
```
Text will be echoed in the clear. Please install the HighLine or Termios libraries to suppress echoed text.
vagrant@127.0.0.1's password:
```

Using ```cap staging evolve:down``` same thing. It won't import the database or rsync the files until I authenticate as the vagrant user.

Maybe not symptomatic of evolve, but I thought either the insecure_key or evolve key was being placed in root/vagrant user for password-less operations.

Thanks for any help you can provide.