### PR TITLE
WP_HOME will not always match SERVER_NAME

### DIFF
--- a/lib/yeoman/templates/Evolution.php
+++ b/lib/yeoman/templates/Evolution.php
@@ -69,8 +69,8 @@ class Evolution
             return false;
         }
 
-        $old_url = self::getHostname();
-        $new_url = htmlspecialchars($_SERVER['HTTP_HOST']);
+        $old_url = '://' . self::getHostname();
+        $new_url = '://' . htmlspecialchars($_SERVER['HTTP_HOST']);
 
         if ($old_url === $new_url) {
             return false;

--- a/lib/yeoman/templates/Evolution.php
+++ b/lib/yeoman/templates/Evolution.php
@@ -63,4 +63,37 @@ class Evolution
         return WP_ENV;
     }
 
+    public static function rewriteUrls()
+    {
+        if (!function_exists('is_blog_installed') || !is_blog_installed()) {
+            return false;
+        }
+
+        $old_url = self::getHostname();
+        $new_url = htmlspecialchars($_SERVER['HTTP_HOST']);
+
+        if ($old_url === $new_url) {
+            return false;
+        }
+
+        // Remove domain from uploads
+        update_option('upload_path', null);
+
+        // Ensure internal WordPress functions map correctly to new url (but don't want to persist in the DB)
+        add_filter('option_home',             function($value) use ($old_url, $new_url) { return str_replace($old_url, $new_url, $value); });
+        add_filter('option_siteurl',          function($value) use ($old_url, $new_url) { return str_replace($old_url, $new_url, $value); });
+        add_filter('option_upload_path',      function($value) use ($old_url, $new_url) { return str_replace($old_url, $new_url, $value); });
+        add_filter('option_upload_url_path',  function($value) use ($old_url, $new_url) { return str_replace($old_url, $new_url, $value); });
+        add_filter('wp_get_attachment_url',   function($value) use ($old_url, $new_url) { return str_replace($old_url, $new_url, $value); });
+
+        // Override URLs in output with local environment URL
+        ob_start( function( $output ) use ( $old_url, $new_url ) {
+            return str_replace( $old_url, $new_url, $output );
+        } );
+
+        register_shutdown_function( function() use ( $old_url, $new_url ) {
+            @ob_end_flush();
+        } );
+    }
+
 }

--- a/lib/yeoman/templates/web/wp-config.php
+++ b/lib/yeoman/templates/web/wp-config.php
@@ -47,3 +47,5 @@ require_once(dirname(__FILE__) . '/../Evolution.php');
   // Replace ABSPATH
   .replace(/define\('ABSPATH'.+\);/, "define('ABSPATH', dirname(__FILE__) . '/wp/');")
 %>
+/** Output rewriting for production.DOMAIN or *.staging.DOMAIN **/
+Evolution::rewriteUrls();


### PR DESCRIPTION
While #37 has fixed most url-related issues, it has some lingering side-effects:

1. Requests to `production.$DOMAIN` will have all links pointing to `$DOMAIN` (or `www.$DOMAIN`, whichever is the canonical)
2. Requests to `$BRANCH.staging.$DOMAIN` will have all links pointing to `staging.$DOMAIN`

There doesn't seem to be a good solution to this, without filtering all content through output buffering.

We _could_ implement this so that output buffering is only turned on when `WP_HOME` and `$_SERVER[SERVER_NAME]` aren't equal, but that's still a hack I'd like to avoid..