### PR TITLE
Fixed sync and pathing issues with wp-cli

### DIFF
--- a/lib/capistrano/bootstrap.rake
+++ b/lib/capistrano/bootstrap.rake
@@ -27,3 +27,6 @@ set :wp_config, Hash[File
   .scan(/DB_(\w+)(?:'|"),[^\'\"]+(?:'|")([^\'\"]*)/)
   .map { |match| [match[0].downcase, match[1]] }
 ]
+
+# Path for wp-cli on local vagrant
+set :local_wp_path,   "/vagrant/web/wp"

--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -9,11 +9,14 @@ namespace :evolve do
         end
       end
 
+      stage_source = args[:source].to_s
+      stage_target = args[:target].to_s
+
       set :wp_cmd, [
-        '"://' + filter_stage(args[:source].to_s) + '/"',
-        '"://' + filter_stage(args[:target].to_s) + '/"',
-        '--path="' + fetch(:wp_path) + '"',
-        '--url="http://' + args[:target].to_s + '.' + fetch(:domain) + '/"',
+        '"://' + filter_stage(stage_source) + '/"',
+        '"://' + filter_stage(stage_target) + '/"',
+        '--path="' + (stage_target == 'local' ? fetch(:local_wp_path) : fetch(:wp_path)) + '"',
+        '--url="http://' + stage_target + '.' + fetch(:domain) + '/"',
       ].join(' ')
     end
 
@@ -64,7 +67,7 @@ namespace :evolve do
           execute :gzip, "-d", fetch(:db_gzip_file)
           execute :vagrant, :up
           execute :vagrant, :ssh, :local,  "-c 'cd /vagrant && mysql -uroot -D \"#{fetch(:wp_config)['name']}_local\" < #{fetch(:db_backup_file)}'"
-          execute :vagrant, :ssh, :local, "-c 'cd #{fetch(:wp_path)} && wp search-replace #{fetch(:wp_cmd)}'"
+          execute :vagrant, :ssh, :local, "-c 'cd #{fetch(:local_wp_path)} && wp search-replace #{fetch(:wp_cmd)}'"
           execute :rm, fetch(:db_backup_file)
         end
 

--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -12,11 +12,13 @@ namespace :evolve do
       stage_source = args[:source].to_s
       stage_target = args[:target].to_s
 
+      invoke "evolve:calc_wp_path", stage_target == 'local'
+
       set :wp_cmd, [
-        '"://' + filter_stage(stage_source) + '/"',
-        '"://' + filter_stage(stage_target) + '/"',
-        '--path="' + (stage_target == 'local' ? fetch(:local_wp_path) : fetch(:wp_path)) + '"',
-        '--url="http://' + stage_target + '.' + fetch(:domain) + '/"',
+        "\"://#{filter_stage(stage_source)}/\"",
+        "\"://#{filter_stage(stage_target)}/\"",
+        "--path=\"#{fetch(:working_wp_path)}\"",
+        "--url=\"http://#{stage_target}.#{fetch(:domain)}/\"",
       ].join(' ')
     end
 
@@ -25,12 +27,14 @@ namespace :evolve do
       set :db_backup_file, DateTime.now.strftime("#{fetch(:wp_config)['name']}.%Y-%m-%d.%H%M%S.sql")
       set :db_gzip_file, "#{fetch(:db_backup_file)}.gz"
 
+      invoke "evolve:calc_wp_path", false
+
       on release_roles(:db) do |host|
         backups_path = "#{deploy_to}/backups"
         execute :mkdir, '-p', backups_path
 
         within backups_path do
-          execute :wp, :db, :export, fetch(:db_backup_file), "--opt", "--path=\"#{fetch(:wp_path)}\"", "--url=\"http://#{fetch(:stage)}.#{fetch(:domain)}/\""
+          execute :wp, :db, :export, fetch(:db_backup_file), "--opt", "--path=\"#{fetch(:working_wp_path)}\"", "--url=\"http://#{fetch(:stage)}.#{fetch(:domain)}/\""
           execute :gzip, fetch(:db_backup_file)
 
           if args[:skip_download]
@@ -67,7 +71,7 @@ namespace :evolve do
           execute :gzip, "-d", fetch(:db_gzip_file)
           execute :vagrant, :up
           execute :vagrant, :ssh, :local,  "-c 'cd /vagrant && mysql -uroot -D \"#{fetch(:wp_config)['name']}_local\" < #{fetch(:db_backup_file)}'"
-          execute :vagrant, :ssh, :local, "-c 'cd #{fetch(:local_wp_path)} && wp search-replace #{fetch(:wp_cmd)}'"
+          execute :vagrant, :ssh, :local, "-c 'cd #{fetch(:working_wp_path)} && wp search-replace #{fetch(:wp_cmd)}'"
           execute :rm, fetch(:db_backup_file)
         end
 
@@ -95,8 +99,8 @@ namespace :evolve do
           upload! fetch(:db_gzip_file), "/tmp/#{fetch(:db_gzip_file)}"
           execute :gzip, "-d", "/tmp/#{fetch(:db_gzip_file)}"
 
-          within fetch(:wp_path) do
-            execute :wp, :db, :import, "/tmp/#{fetch(:db_backup_file)}", "--path=\"#{fetch(:wp_path)}\"", "--url=\"http://#{fetch(:stage)}.#{fetch(:domain)}/\""
+          within fetch(:working_wp_path) do
+            execute :wp, :db, :import, "/tmp/#{fetch(:db_backup_file)}", "--path=\"#{fetch(:working_wp_path)}\"", "--url=\"http://#{fetch(:stage)}.#{fetch(:domain)}/\""
             execute :wp, :'search-replace', fetch(:wp_cmd)
           end
 

--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -55,6 +55,8 @@ namespace :evolve do
 
     task :down do |task|
       begin
+        raise "Cannot sync db down from local!" if fetch(:stage) == 'local'
+
         invoke "evolve:db:backup"
         invoke "evolve:db:prepare", fetch(:stage), "local"
 
@@ -74,6 +76,8 @@ namespace :evolve do
 
     task :up do |task|
       begin
+        raise "Cannot sync db up from #{fetch(:stage)}!" if fetch(:stage) != 'local'
+
         invoke "evolve:confirm", "You are about to destroy & override the \"#{fetch(:stage)}\" database!"
         invoke "evolve:db:backup", true
         invoke "evolve:db:prepare", "local", fetch(:stage)

--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -79,7 +79,7 @@ namespace :evolve do
 
     task :up do |task|
       begin
-        raise "Cannot sync db up from #{fetch(:stage)}!" if fetch(:stage) != 'local'
+        raise "Cannot sync db up to local!" if fetch(:stage) == 'local'
 
         invoke "evolve:confirm", "You are about to destroy & override the \"#{fetch(:stage)}\" database!"
         invoke "evolve:db:backup", true

--- a/lib/capistrano/tasks/files.rake
+++ b/lib/capistrano/tasks/files.rake
@@ -7,6 +7,8 @@ namespace :evolve do
 
     task :down do |task|
       begin
+        raise "Cannot sync files down from local!" if fetch(:stage) == 'local'
+
         local_uploads = "/vagrant/web/wp-content/uploads"
         remote_uploads = "#{release_path}/web/wp-content/uploads"
         uploads_exist = false
@@ -38,6 +40,8 @@ namespace :evolve do
 
     task :up do |task|
       begin
+        raise "Cannot sync files up from #{fetch(:stage)}!" if fetch(:stage) != 'local'
+
         invoke "evolve:confirm", "You are about to overwrite \"#{fetch(:stage)}\" files!"
 
         local_uploads = "/vagrant/web/wp-content/uploads"

--- a/lib/capistrano/tasks/files.rake
+++ b/lib/capistrano/tasks/files.rake
@@ -40,7 +40,7 @@ namespace :evolve do
 
     task :up do |task|
       begin
-        raise "Cannot sync files up from #{fetch(:stage)}!" if fetch(:stage) != 'local'
+        raise "Cannot sync files up to local!" if fetch(:stage) == 'local'
 
         invoke "evolve:confirm", "You are about to overwrite \"#{fetch(:stage)}\" files!"
 

--- a/lib/capistrano/tasks/util.rake
+++ b/lib/capistrano/tasks/util.rake
@@ -16,7 +16,7 @@ namespace :evolve do
           end
         end
 
-        raise "WP path '#{wp_path}' does not exist on #{stage_target}" unless test "[ -d #{wp_path} ]"
+        raise "WP path '#{wp_path}' does not exist on #{fetch(:stage)}" unless test "[ -d #{wp_path} ]"
       end
 
       set :working_wp_path, wp_path

--- a/lib/capistrano/tasks/wp.rake
+++ b/lib/capistrano/tasks/wp.rake
@@ -2,9 +2,11 @@ namespace :wp do
   desc "Execute WP-CLI command remotely"
   rule /^wp\:/ do |task|
     begin
+      invoke "evolve:calc_wp_path", fetch(:stage) == 'local'
+
       on release_roles(:db) do
-        within fetch(:wp_path) do
-          execute "#{task.name.split(":").join(" ")} --path=\"#{fetch(:wp_path)}\" --url=\"http://#{fetch(:stage)}.#{fetch(:domain)}/\""
+        within fetch(:working_wp_path) do
+          execute "#{task.name.split(":").join(" ")} --path=\"#{fetch(:working_wp_path)}\" --url=\"http://#{fetch(:stage)}.#{fetch(:domain)}/\""
         end
       end
 

--- a/lib/yeoman/templates/lib/capistrano/deploy/local.rb
+++ b/lib/yeoman/templates/lib/capistrano/deploy/local.rb
@@ -3,4 +3,4 @@ server 'local.<%= props.domain %>',
   user:         fetch(:user),
   ssh_options:  fetch(:ssh_options)
 
-set :wp_path,   "/vagrant/web/wp"
+set :wp_path,   fetch(:local_wp_path)


### PR DESCRIPTION
Scope of this PR has changed significantly since it was started, so summarizing the changes:

* [x] [Defines a local wp path](https://github.com/evolution/wordpress/pull/64/files#diff-8b4375835c2a4e397b434c8db725312aR32) in bootstrap
* [x] [Reuses said local path](https://github.com/evolution/wordpress/pull/64/files#diff-ec349a38925b8585bf0ad61acbfc8a54R6) in generated local.rb
* [x] [Adds util task](https://github.com/evolution/wordpress/pull/64/files#diff-9df3b7e8ffe49ea41076385f663daa72R2) to calculate working wp path for given stage
* [x] Uses said util task anywhere that wp-cli commands are run by capistrano, [including the standalone wp task](https://github.com/evolution/wordpress/pull/64/files#diff-54aff2561818567205dd9b6a97a53e8bR5)
* [x] Prevents syncing up/down on a working stage of `local`

--

Fixed an issue where `db:down` was incorrectly using the remote stage's `wp_path` against the local target stage (and failing).

Also added exceptions when doing a down from local stage, ~~or an up from a remote stage~~ -- this is wrong...confused myself with my own terminology.

Conceptually speaking we have three distinct stages to worry about during sync:
* **working stage** - this is what the current capistrano command is running under; eg `cap {$stage} {$task}`
* **source stage** - this is the stage _from which_ we're syncing; in `down` this is the remote, and in `up` this is local
* **target stage** - this is the stage _to which_ we're syncing; in `down` this is local, and in `up` this is the remote

To review, the sync tasks should be preventing an up or down with a **working stage** of `local`.

--

Output from this issue (that I found entirely by accident, while testing #62):

```bash
$ bundle exec cap staging evolve:db:down
...some output removed for brevity sake...
INFO[af1302ab] Running /usr/bin/env vagrant ssh local -c 'cd /vagrant && mysql -uroot -D "example_db_local" < example_db.2015-06-25.135213.sql' on localhost
DEBUG[af1302ab] Command: /usr/bin/env vagrant ssh local -c 'cd /vagrant && mysql -uroot -D "example_db_local" < example_db.2015-06-25.135213.sql'
INFO[af1302ab] Finished in 2.580 seconds with exit status 0 (successful).
INFO[ae35d28b] Running /usr/bin/env vagrant ssh local -c 'cd /var/www/example.com/staging/feature-branch/current/web/wp && wp search-replace "://staging.example.com/" "://local.example.com/" --path="/var/www/example.com/staging/feature-branch/current/web/wp" --url="http://local.example.com/"' on localhost
DEBUG[ae35d28b] Command: /usr/bin/env vagrant ssh local -c 'cd /var/www/example.com/staging/feature-branch/current/web/wp && wp search-replace "://staging.example.com/" "://local.example.com/" --path="/var/www/example.com/staging/feature-branch/current/web/wp" --url="http://local.example.com/"'
DEBUG[89bdde17] Running /usr/bin/env [ -f /var/log/evolution/wordpress.log ] && [ $(stat -c %U /var/log/evolution/wordpress.log) == 'deploy' ] on staging.example.com
DEBUG[89bdde17] Command: [ -f /var/log/evolution/wordpress.log ] && [ $(stat -c %U /var/log/evolution/wordpress.log) == 'deploy' ]
DEBUG[89bdde17] Finished in 0.052 seconds with exit status 0 (successful).
INFO[10e7aaea] Running /usr/bin/env echo Thu\ Jun\ 25\ 13:52:24\ 2015\	ekaufman@discordia.local\	evolve:db:down\	Failure >> /var/log/evolution/wordpress.log on staging.example.com
DEBUG[10e7aaea] Command: /usr/bin/env echo Thu\ Jun\ 25\ 13:52:24\ 2015\	ekaufman@discordia.local\	evolve:db:down\	Failure >> /var/log/evolution/wordpress.log
INFO[10e7aaea] Finished in 0.050 seconds with exit status 0 (successful).
cap aborted!
SSHKit::Command::Failed: vagrant exit status: 256
vagrant stdout: Nothing written
vagrant stderr: bash: line 0: cd: /var/www/example.com/staging/feature-branch/current/web/wp: No such file or directory
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/command.rb:97:in `exit_status='
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:56:in `block in _execute'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `tap'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `_execute'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:26:in `execute'
/Users/ekaufman/GIT/CMN/Example.com/bower_components/evolution-wordpress/lib/capistrano/tasks/db.rake:65:in `block (4 levels) in <top (required)>'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `instance_exec'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `run'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/sshkit-1.5.1/lib/sshkit/dsl.rb:10:in `run_locally'
/Users/ekaufman/GIT/CMN/Example.com/bower_components/evolution-wordpress/lib/capistrano/tasks/db.rake:61:in `block (3 levels) in <top (required)>'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/capistrano-3.2.1/lib/capistrano/application.rb:15:in `run'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/gems/capistrano-3.2.1/bin/cap:3:in `<top (required)>'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/bin/cap:23:in `load'
/Users/ekaufman/GIT/CMN/Example.com/vendor/bundle/ruby/2.0.0/bin/cap:23:in `<main>'
Tasks: TOP => evolve:db:down
(See full trace by running task with --trace)
```