### PR TITLE
Shortening apt cache valid time

### DIFF
--- a/lib/ansible/roles/common/tasks/main.yml
+++ b/lib/ansible/roles/common/tasks/main.yml
@@ -9,7 +9,7 @@
   debug:          var=new_hostname
 
 - name:           Update apt cache
-  apt:            update_cache=yes cache_valid_time="{{ 60 * 60 * 24 * 30 }}"
+  apt:            update_cache=yes cache_valid_time="{{ 60 * 60 * 24 }}"
   sudo:           yes
 
 - name:           Install common packages


### PR DESCRIPTION
Encountered an issue (pointed out by @germanny) with the [latest trusty64 image](https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/20150609.0.10), which is (at time of writing this) 25 days old and _already_ has outdated package urls. Since our configured `cache_valid_time` is 30 days, the apt update was being bypassed and apt installs were failing.

Shortening the valid time to 1 day solves the issue