### PR TITLE
Mysql hostname socket vs host ip

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,9 @@
+# Frequently Asked Questions
+
+This document lists commonly encountered issues, their likely causes, and likely solutions.
+
+### Error establishing a database connection
+
+Is the MySQL database is not running? Restart it with `sudo service mysql restart`
+
+Is `DB_HOST` in your wordpress configuration set to `localhost`? If so, there may be a mysql local socket issue...set it instead to `127.0.0.1` to use TCP/IP, and [see the documentation behind this known issue](http://php.net/mysql_connect#refsect1-function.mysql-connect-notes)

--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -386,7 +386,7 @@ var WordpressGenerator = yeoman.generators.Base.extend({
         type:     'text',
         name:     'DB_HOST',
         message:  'Database host',
-        default:  function() { return existing('DB_HOST') || 'localhost'; }
+        default:  function() { return existing('DB_HOST') || '127.0.0.1'; }
       });
 
       done();


### PR DESCRIPTION
This addresses a known PHP/MySQL feature, where a hostname of "localhost" is implicitly overridden by a local socket.

If said socket is not present, we see the ubiquitous `Error establishing a database connection` message. Explicitly using TCP/IP fixes this.
 
See: http://php.net/mysql_connect#refsect1-function.mysql-connect-notes