### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/lib/yeoman/templates/_gitignore
+++ b/lib/yeoman/templates/_gitignore
@@ -50,5 +50,6 @@ nbproject
 .vagrant
 _notes
 bower_components
+node_modules
 backups
 web/wp


### PR DESCRIPTION
Would you want to add `node_modules` to the `.gitignore`? I noticed these were set to be committed to my repo.

And I don't know if this is too specific, but the frontend devs like `**/assets/dev` added to the `.gitignore` so our development files are not committed.