### PR TITLE
Regeneration of site should not overwrite custom gitignores 

### DIFF
--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -477,7 +477,7 @@ var WordpressGenerator = yeoman.generators.Base.extend({
   prepareGitignore: function () {
     try {
       this.gitignoreFile = this.readFileAsString(path.join(this.env.cwd, '.gitignore'));
-      this.gitignoreFile = this.gitignoreFile.match(/[\r\n]+# Generated file, don't edit above this line[\r\n]*([\S\s]*)[\r\n]*$/i)[1];
+      this.gitignoreFile = this.gitignoreFile.match(/[\r\n]+# Generated file, don't edit above this line[\r\n]*([\S\s]*?)[\r\n]*$/i)[1];
     } catch(e) {
       this.gitignoreFile = '';
     }

--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -465,7 +465,7 @@ var WordpressGenerator = yeoman.generators.Base.extend({
   prepareHtaccess: function() {
     try {
       this.htaccessFile = this.readFileAsString(path.join(this.env.cwd, 'web', '.htaccess'));
-      this.htaccessFile = this.htaccessFile.replace(/# BEGIN Evolution WordPress(?:.|[\r\n]+)+?# END Evolution WordPress[\r\n]*/i, '');
+      this.htaccessFile = this.htaccessFile.replace(/# BEGIN Evolution WordPress(?:.|[\r\n]+)+?# END Evolution WordPress[\r\n]*/i, '').trim();
 
       this.htaccessWpBlock = !!this.htaccessFile.match(/# BEGIN WordPress(?:.|[\r\n]+)+?# END WordPress[\r\n]*/i);
     } catch(e) {

--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -474,6 +474,15 @@ var WordpressGenerator = yeoman.generators.Base.extend({
     }
   },
 
+  prepareGitignore: function () {
+    try {
+      this.gitignoreFile = this.readFileAsString(path.join(this.env.cwd, '.gitignore'));
+      this.gitignoreFile = this.gitignoreFile.match(/[\r\n]+# Generated file, don't edit above this line[\r\n]*([\S\s]*)[\r\n]*$/i)[1];
+    } catch(e) {
+      this.gitignoreFile = '';
+    }
+  },
+
   prepareRoles: function() {
     this.props.roles = WordpressGenerator.roles.map(function(role) {
       role.checked = !!~this.props.roles.indexOf(role.value);

--- a/lib/yeoman/templates/_gitignore
+++ b/lib/yeoman/templates/_gitignore
@@ -52,3 +52,6 @@ _notes
 bower_components
 backups
 web/wp
+
+# Generated file, don't edit above this line
+<%= gitignoreFile %>


### PR DESCRIPTION
Similar to how we preserve some htaccess content on site regen, preserve everything in gitignore past an anchor comment: `# Generated file, don't edit above this line`