### PR TITLE
After upg to 1.2.0, evolve:down:files requires manual host key verification

### DIFF
--- a/lib/capistrano/tasks/files.rake
+++ b/lib/capistrano/tasks/files.rake
@@ -2,7 +2,7 @@ namespace :evolve do
   namespace :files do
     task :prepare, :path_from, :path_to do |task, args|
       invoke "evolve:prepare_key"
-      set :rsync_cmd, "-c 'cd /vagrant && rsync -e \"ssh -i #{fetch(:ssh_keyfile)}\" -avvru --delete --copy-links --progress #{args[:path_from]}/ #{args[:path_to]}/'"
+      set :rsync_cmd, "-c 'cd /vagrant && rsync -e \"ssh -i #{fetch(:ssh_keyfile)} -o StrictHostKeyChecking=no\" -avvru --delete --copy-links --progress #{args[:path_from]}/ #{args[:path_to]}/'"
     end
 
     task :down do |task|


### PR DESCRIPTION
With an existing local vm, and existing remote vm, reprovisioned after 1.2.0, ```evolve:down:files``` gets an rsync error with host verification:

```
mcheck@MRTEENY:bam.com (2.2.1@evolve)(master) $ cap staging evolve:down:files
DEBUG[d795296d] Running /usr/bin/env [ -d /var/www/bam.com/staging/master/current/web/wp-content/uploads ] on staging.bam.com
DEBUG[d795296d] Command: [ -d /var/www/bam.com/staging/master/current/web/wp-content/uploads ]
DEBUG[d795296d] Finished in 1.829 seconds with exit status 0 (successful).
INFO[7b4d776e] Running /usr/bin/env vagrant up on localhost
DEBUG[7b4d776e] Command: /usr/bin/env vagrant up
DEBUG[7b4d776e] 	Bringing machine 'local' up with 'virtualbox' provider...
DEBUG[7b4d776e] 	==> local: Checking if box 'ubuntu/trusty64' is up to date...
DEBUG[7b4d776e] 	==> local: A newer version of the box 'ubuntu/trusty64' is available! You currently
DEBUG[7b4d776e] 	==> local: have version '14.04'. The latest is version '20150609.0.10'. Run
DEBUG[7b4d776e] 	==> local: `vagrant box update` to update.
DEBUG[7b4d776e] 	==> local: VirtualBox VM is already running.
DEBUG[7b4d776e] 	==> local: Checking for host entries
INFO[7b4d776e] Finished in 5.134 seconds with exit status 0 (successful).
INFO[ff24e5aa] Running /usr/bin/env chmod 600 ./lib/ansible/files/ssh/id_rsa on localhost
DEBUG[ff24e5aa] Command: chmod 600 ./lib/ansible/files/ssh/id_rsa
INFO[ff24e5aa] Finished in 0.004 seconds with exit status 0 (successful).
INFO[6cc3cabc] Running /usr/bin/env vagrant ssh local -c 'cd /vagrant && rsync -e "ssh -i ./lib/ansible/files/ssh/id_rsa" -avvru --delete --copy-links --progress deploy@staging.bam.com:/var/www/bam.com/staging/master/current/web/wp-content/uploads/ /vagrant/web/wp-content/uploads/' on localhost
DEBUG[6cc3cabc] Command: /usr/bin/env vagrant ssh local -c 'cd /vagrant && rsync -e "ssh -i ./lib/ansible/files/ssh/id_rsa" -avvru --delete --copy-links --progress deploy@staging.bam.com:/var/www/bam.com/staging/master/current/web/wp-content/uploads/ /vagrant/web/wp-content/uploads/'
vagrant@127.0.0.1's password: 
DEBUG[1bbb7486] Running /usr/bin/env [ -f /var/log/evolution/wordpress.log ] && [ $(stat -c %U /var/log/evolution/wordpress.log) == 'deploy' ] on staging.bam.com
DEBUG[1bbb7486] Command: [ -f /var/log/evolution/wordpress.log ] && [ $(stat -c %U /var/log/evolution/wordpress.log) == 'deploy' ]
DEBUG[1bbb7486] Finished in 0.077 seconds with exit status 0 (successful).
INFO[0c482bb5] Running /usr/bin/env echo Wed\ Jul\ 29\ 08:23:19\ 2015\	mcheck@MRTEENY.local\	evolve:files:down\	Failure >> /var/log/evolution/wordpress.log on staging.bam.com
DEBUG[0c482bb5] Command: /usr/bin/env echo Wed\ Jul\ 29\ 08:23:19\ 2015\	mcheck@MRTEENY.local\	evolve:files:down\	Failure >> /var/log/evolution/wordpress.log
INFO[0c482bb5] Finished in 0.078 seconds with exit status 0 (successful).
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing on host staging.bam.com: vagrant exit status: 3072
vagrant stdout: opening connection using: ssh -i ./lib/ansible/files/ssh/id_rsa -l deploy staging.bam.com rsync --server --sender -vvulLogDtpre.iLs . /var/www/bam.com/staging/master/current/web/wp-content/uploads/  (12 args)
vagrant stderr: Host key verification failed.
rsync: connection unexpectedly closed (0 bytes received so far) [Receiver]
rsync error: error in rsync protocol data stream (code 12) at io.c(226) [Receiver=3.1.0]
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/command.rb:97:in `exit_status='
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:56:in `block in _execute'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `tap'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `_execute'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:26:in `execute'
/Users/mcheck/clients/bam/bam.com/bower_components/evolution-wordpress/lib/capistrano/tasks/files.rake:28:in `block (5 levels) in <top (required)>'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `instance_exec'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `run'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/dsl.rb:10:in `run_locally'
/Users/mcheck/clients/bam/bam.com/bower_components/evolution-wordpress/lib/capistrano/tasks/files.rake:27:in `block (4 levels) in <top (required)>'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `instance_exec'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `run'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/runners/parallel.rb:13:in `block (2 levels) in execute'
SSHKit::Command::Failed: vagrant exit status: 3072
vagrant stdout: opening connection using: ssh -i ./lib/ansible/files/ssh/id_rsa -l deploy staging.bam.com rsync --server --sender -vvulLogDtpre.iLs . /var/www/bam.com/staging/master/current/web/wp-content/uploads/  (12 args)
vagrant stderr: Host key verification failed.
rsync: connection unexpectedly closed (0 bytes received so far) [Receiver]
rsync error: error in rsync protocol data stream (code 12) at io.c(226) [Receiver=3.1.0]
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/command.rb:97:in `exit_status='
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:56:in `block in _execute'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `tap'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `_execute'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:26:in `execute'
/Users/mcheck/clients/bam/bam.com/bower_components/evolution-wordpress/lib/capistrano/tasks/files.rake:28:in `block (5 levels) in <top (required)>'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `instance_exec'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `run'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/dsl.rb:10:in `run_locally'
/Users/mcheck/clients/bam/bam.com/bower_components/evolution-wordpress/lib/capistrano/tasks/files.rake:27:in `block (4 levels) in <top (required)>'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `instance_exec'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `run'
/Users/mcheck/.rvm/gems/ruby-2.2.1@evolve/gems/sshkit-1.5.1/lib/sshkit/runners/parallel.rb:13:in `block (2 levels) in execute'
Tasks: TOP => evolve:files:down
(See full trace by running task with --trace)
```

I can run the command locally, and approve the host key fingerprint:
```
vagrant ssh local -c 'cd /vagrant && rsync -e "ssh -i ./lib/ansible/files/ssh/id_rsa" -avvru --delete --copy-links --progress deploy@staging.bam.com:/var/www/bam.com/staging/master/current/web/wp-content/uploads/ /vagrant/web/wp-content/uploads/'
```

Is this due to taking out the ssh configuration from ```Vagrantfile```?


