### PR TITLE
Adjust php's ```max_file_uploads``` size in provision

### DIFF
--- a/lib/ansible/roles/php/tasks/main.yml
+++ b/lib/ansible/roles/php/tasks/main.yml
@@ -35,3 +35,7 @@
 - name:           Update php.ini's memory_limit
   lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php_settings.memory_limit }}M'
   sudo:           yes
+
+- name:           Update php.ini's upload_max_filesize
+  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='upload_max_filesize' line='upload_max_filesize = 16M'
+  sudo:           yes

--- a/lib/ansible/roles/php/tasks/main.yml
+++ b/lib/ansible/roles/php/tasks/main.yml
@@ -29,13 +29,13 @@
   when:           php_settings.memory_limit is undefined
 
 - name:           Update php.ini's date.timezone
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='date\.timezone' line='date.timezone = "America/Chicago"'
+  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*date\.timezone' line='date.timezone = "America/Chicago"'
   sudo:           yes
 
 - name:           Update php.ini's memory_limit
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php_settings.memory_limit }}M'
+  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php_settings.memory_limit }}M'
   sudo:           yes
 
 - name:           Update php.ini's upload_max_filesize
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='upload_max_filesize' line='upload_max_filesize = 16M'
+  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*upload_max_filesize' line='upload_max_filesize = 16M'
   sudo:           yes


### PR DESCRIPTION
Since I find myself adjusting this with every install, request to could add it to the provision script.
Does this make sense to adjust php's ```max_file_upload``` here?
Or perhaps there a better place to adjust it, would it be better in wp-config as an ini-set? For me, the ini is fine since 16M is small these days...

Something like this in ```lib/ansible/roles/php/tasks/main.yml```
```
- name:           Update php.ini's max_file_upload
  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='upload_max_filesize' line='upload_max_filesize  = 16M'
  sudo:           yes
```

