### PR TITLE
SSL generator prompt

### DIFF
--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -114,7 +114,13 @@ var WordpressGenerator = yeoman.generators.Base.extend({
   },
 
   promptForSsl: function() {
-    var existing = glob.sync('lib/ansible/files/ssl/*.pem').length;
+    var defaultSsl = true;
+
+    try {
+      var provisionYml = this.readFileAsString(path.join(this.env.cwd, 'lib', 'ansible', 'provision.yml'));
+      defaultSsl = !!provisionYml.match(/^\s*-\s+pound/m);
+    } catch(e) {};
+
     var choices  = [
       {
         name:   'Yes, HTTPS (SSL)',
@@ -126,7 +132,7 @@ var WordpressGenerator = yeoman.generators.Base.extend({
       },
     ];
 
-    if(!existing) {
+    if(!defaultSsl) {
       choices.reverse();
     }
 
@@ -137,7 +143,7 @@ var WordpressGenerator = yeoman.generators.Base.extend({
       choices:  choices
     });
 
-    if(existing) {
+    if(glob.sync('lib/ansible/files/ssl/*.pem').length) {
       this.prompts.push({
         type:     'list',
         name:     'sslOverwrite',

--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -114,23 +114,30 @@ var WordpressGenerator = yeoman.generators.Base.extend({
   },
 
   promptForSsl: function() {
+    var existing = glob.sync('lib/ansible/files/ssl/*.pem').length;
+    var choices  = [
+      {
+        name:   'Yes, HTTPS (SSL)',
+        value:  true,
+      },
+      {
+        name:   'No, HTTP-only',
+        value:  false,
+      },
+    ];
+
+    if(!existing) {
+      choices.reverse();
+    }
+
     this.prompts.push({
       type:     'list',
       name:     'ssl',
       message:  'Will this site serve HTTPS (SSL) traffic?',
-      choices:  [
-        {
-          name:   'Yes, HTTPS (SSL)',
-          value:  true,
-        },
-        {
-          name:   'No, HTTP-only',
-          value:  false,
-        },
-      ]
+      choices:  choices
     });
 
-    if(glob.sync('lib/ansible/files/ssl/*.pem').length) {
+    if(existing) {
       this.prompts.push({
         type:     'list',
         name:     'sslOverwrite',


### PR DESCRIPTION
When running against an existing site, the generator should detect:

1. whether a pound role exists in `provision.yml`, and default the use ssl prompt accordingly
2. whether there are existing ssl certs and prompt whether to overwrite them