### PR TITLE
Permissions issue on rsync to remote

### DIFF
--- a/lib/capistrano/tasks/files.rake
+++ b/lib/capistrano/tasks/files.rake
@@ -54,6 +54,8 @@ namespace :evolve do
         end
 
         if uploads_exist
+          invoke "evolve:permissions"
+
           on roles(:web) do |host|
             invoke "evolve:files:prepare", local_uploads, "#{fetch(:user)}@#{host}:#{remote_uploads}"
             run_locally do

--- a/lib/capistrano/tasks/server.rake
+++ b/lib/capistrano/tasks/server.rake
@@ -78,6 +78,8 @@ namespace :evolve do
       execute :sudo, "find -L #{release_path}/web -type d -exec chown :www-data {} \\; -exec chmod 775 {} \\; -exec chmod g+s {} \\;"
       # Ensure files are group readable
       execute :sudo, "find -L #{release_path}/web -type f -exec chmod 664 {} \\;"
+      # Ensure wp-content directories are owned by deploy
+      execute :sudo, "find -L #{release_path}/web/wp-content -type d -exec chown deploy {} \\;"
     end
   end
 


### PR DESCRIPTION
I'm getting this error on `bundle exec cap staging evolve:up:files`. It uploaded the files, so I'm not sure if this is a problem.

List of files uploaded, and then:
```
sent 55,493 bytes  received 131,803 bytes  124,864.00 bytes/sec
total size is 67,628,076  speedup is 361.08
vagrant stderr: rsync: failed to set times on "/var/www/example.com/staging/states-refresh/current/web/wp-content/uploads/2015": Operation not permitted (1)
rsync: failed to set times on "/var/www/example.com/staging/states-refresh/current/web/wp-content/uploads/2015/07": Operation not permitted (1)
rsync: failed to set times on "/var/www/example.com/staging/states-refresh/current/web/wp-content/uploads/2015/08": Operation not permitted (1)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1183) [sender=3.1.0]
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/command.rb:97:in `exit_status='
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:56:in `block in _execute'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `tap'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:37:in `_execute'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:26:in `execute'
/Users/germanny/Sites/Example.com/bower_components/evolution-wordpress/lib/capistrano/tasks/files.rake:60:in `block (5 levels) in <top (required)>'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `instance_exec'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/local.rb:14:in `run'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/dsl.rb:10:in `run_locally'
/Users/germanny/Sites/Example.com/bower_components/evolution-wordpress/lib/capistrano/tasks/files.rake:59:in `block (4 levels) in <top (required)>'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `instance_exec'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `run'
/Library/Ruby/Gems/2.0.0/gems/sshkit-1.5.1/lib/sshkit/runners/parallel.rb:13:in `block (2 levels) in execute'
Tasks: TOP => evolve:files:up
(See full trace by running task with --trace)
```