### PR TITLE
Plugins adding folders/files to wp root cannot be cleaned up on deploy

### DIFF
--- a/lib/capistrano/bootstrap.rake
+++ b/lib/capistrano/bootstrap.rake
@@ -30,3 +30,10 @@ set :wp_config, Hash[File
 
 # Path for wp-cli on local vagrant
 set :local_wp_path,   "/vagrant/web/wp"
+
+# fix permissions before deployment
+namespace :deploy do
+  before :started, :release_permissions do
+    invoke "evolve:permissions"
+  end
+end

--- a/lib/capistrano/tasks/server.rake
+++ b/lib/capistrano/tasks/server.rake
@@ -75,11 +75,11 @@ namespace :evolve do
   task :permissions do
     on release_roles(:web) do
       # Ensure directories are group-owned by apache & group executable; SGID
-      execute :sudo, "find -L #{release_path}/web -type d -exec chown :www-data {} \\; -exec chmod 775 {} \\; -exec chmod g+s {} \\;"
+      execute :sudo, "find -L #{deploy_to}/releases/*/web -type d -exec chown :www-data {} \\; -exec chmod 775 {} \\; -exec chmod g+s {} \\;"
       # Ensure files are group readable
-      execute :sudo, "find -L #{release_path}/web -type f -exec chmod 664 {} \\;"
+      execute :sudo, "find -L #{deploy_to}/releases/*/web -type f -exec chmod 664 {} \\;"
       # Ensure wp-content directories are owned by deploy
-      execute :sudo, "find -L #{release_path}/web/wp-content -type d -exec chown deploy {} \\;"
+      execute :sudo, "find -L #{deploy_to}/releases/*/web/wp-content -type d -exec chown deploy {} \\;"
     end
   end
 

--- a/lib/capistrano/tasks/server.rake
+++ b/lib/capistrano/tasks/server.rake
@@ -74,12 +74,17 @@ namespace :evolve do
   desc "Fix remote filesystem permissions"
   task :permissions do
     on release_roles(:web) do
-      # Ensure directories are group-owned by apache & group executable; SGID
-      execute :sudo, "find -L #{deploy_to}/releases/*/web -type d -exec chown :www-data {} \\; -exec chmod 775 {} \\; -exec chmod g+s {} \\;"
-      # Ensure files are group readable
-      execute :sudo, "find -L #{deploy_to}/releases/*/web -type f -exec chmod 664 {} \\;"
-      # Ensure wp-content directories are owned by deploy
-      execute :sudo, "find -L #{deploy_to}/releases/*/web/wp-content -type d -exec chown deploy {} \\;"
+      if test :ls, "#{deploy_to}/releases/*/web"
+        # Ensure directories are group-owned by apache & group executable; SGID
+        execute :sudo, "find -L #{deploy_to}/releases/*/web -type d -exec chown :www-data {} \\; -exec chmod 775 {} \\; -exec chmod g+s {} \\;"
+        # Ensure files are group readable
+        execute :sudo, "find -L #{deploy_to}/releases/*/web -type f -exec chmod 664 {} \\;"
+
+        if test :ls, "#{deploy_to}/releases/*/web/wp-content"
+          # Ensure wp-content directories are owned by deploy
+          execute :sudo, "find -L #{deploy_to}/releases/*/web/wp-content -type d -exec chown deploy {} \\;"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
We're using WP CSV to move data, and it places a ```wpcsv_backups``` dir in the wp root with it's own ```.htaccess` owned by ```www-data```

```
$ ls -al
total 12
drwxr-xr-x 2 www-data www-data 4096 Sep 18 17:00 .
drwxrwxr-x 3 deploy   deploy   4096 Sep 21 15:14 ..
-rw-r--r-- 1 www-data www-data   13 Sep 18 17:00 .htaccess
```

```cap evolve:permissions``` ensures ```www-data``` is group-owned, but does not give deploy power to manage ```www-data``` created files in the wp dir.

When ```cap staging deploy``` is run and cleanup to remove older revisions, current permissions do not allow revision folder to be removed and ```cap deploy``` will fail. Actually, it does deploy, it cannot finish, however and dumps the error.

```
INFO[7a017f79] Running /usr/bin/env rm -rf /var/www/bambam.com/production/master/releases/20150918210009 /var/www/bambam.com/production/master/releases/20150919000959 on production.bambam.com
DEBUG[7a017f79] Command: /usr/bin/env rm -rf /var/www/bambam.com/production/master/releases/20150918210009 /var/www/bambam.com/production/master/releases/20150919000959
DEBUG[7a017f79] 	rm: 
DEBUG[7a017f79] 	cannot remove ‘/var/www/bambam.com/production/master/releases/20150918210009/web/wp/wpcsv_backups/.htaccess’
```

So.. I thought deploy was running ```sudo``` at that point, but I guess I'm mistaken.

Suggestions for a good way to handle the revision removal? Change the deploy-removal to run as sudo, or perhaps run an extended permissions modification before removal?
