### PR TITLE
Adding swapfile to provisioning

### DIFF
--- a/lib/ansible/roles/common/defaults/main.yml
+++ b/lib/ansible/roles/common/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+swap:
+  path: /swapfile
+  swappiness: 10
+  vfs_cache_pressure: 50

--- a/lib/ansible/roles/common/defaults/main.yml
+++ b/lib/ansible/roles/common/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-swap:
-  path: /swapfile
-  swappiness: 10
-  vfs_cache_pressure: 50
+swap__path: /swapfile
+swap__swappiness: 10
+swap__vfs_cache_pressure: 50

--- a/lib/ansible/roles/common/tasks/main.yml
+++ b/lib/ansible/roles/common/tasks/main.yml
@@ -34,3 +34,6 @@
 - name:           Configure logrotate for evolution logs
   copy:           src=logrotate dest=/etc/logrotate.d/evolution mode=0644
   sudo:           yes
+
+- include:        swap.yml
+  when:           ansible_swaptotal_mb == 0

--- a/lib/ansible/roles/common/tasks/swap.yml
+++ b/lib/ansible/roles/common/tasks/swap.yml
@@ -12,31 +12,31 @@
   when:           swapfile_size_mb.stdout == ''
 
 - name:           Write swapfile
-  command:        fallocate -l {{swapfile_size_mb.stdout}}M {{swap.path}}
+  command:        fallocate -l {{swapfile_size_mb.stdout}}M {{swap__path}}
   sudo:           yes
 
 - name:           Set permissions
-  file:           path={{swap.path}} mode=600 owner=root group=root
+  file:           path={{swap__path}} mode=600 owner=root group=root
   sudo:           yes
 
 - name:           Create swapfile
-  command:        mkswap {{swap.path}}
+  command:        mkswap {{swap__path}}
   sudo:           yes
 
 - name:           Enable swapfile
-  command:        swapon {{swap.path}}
+  command:        swapon {{swap__path}}
   sudo:           yes
 
 - name:           Add swapfile to /etc/fstab
-  lineinfile:     dest=/etc/fstab state=present line="{{ swap.path }}   none    swap    sw    0   0"
+  lineinfile:     dest=/etc/fstab state=present line="{{ swap__path }}   none    swap    sw    0   0"
   sudo:           yes
 
 - name:           Configure vm.swappiness
-  lineinfile:     dest=/etc/sysctl.conf line="vm.swappiness = {{ swap.swappiness }}" regexp="^vm.swappiness\s*?=" state=present
+  lineinfile:     dest=/etc/sysctl.conf line="vm.swappiness = {{ swap__swappiness }}" regexp="^vm.swappiness\s*?=" state=present
   sudo:           yes
 
 - name:           Configure vm.vfs_cache_pressure
-  lineinfile:     dest=/etc/sysctl.conf line="vm.vfs_cache_pressure = {{ swap.vfs_cache_pressure }}" regexp="^vm.vfs_cache_pressure\s*?=" state=present
+  lineinfile:     dest=/etc/sysctl.conf line="vm.vfs_cache_pressure = {{ swap__vfs_cache_pressure }}" regexp="^vm.vfs_cache_pressure\s*?=" state=present
   sudo:           yes
 
 - name:           Reload sysctl

--- a/lib/ansible/roles/common/tasks/swap.yml
+++ b/lib/ansible/roles/common/tasks/swap.yml
@@ -1,0 +1,44 @@
+---
+- name:           Calculate ideal swapfile size
+  template:       src=swapsize.j2 dest=/tmp/swapsize
+
+- name:           Fetch swapfile size
+  shell:          "cat /tmp/swapsize | tr -d '[:space:]'"
+  register:       swapfile_size_mb
+
+- debug:          var=swapfile_size_mb.stdout
+
+- fail:           msg="Could not determine swapfile size with available diskspace"
+  when:           swapfile_size_mb.stdout == ''
+
+- name:           Write swapfile
+  command:        fallocate -l {{swapfile_size_mb.stdout}}M {{swap.path}}
+  sudo:           yes
+
+- name:           Set permissions
+  file:           path={{swap.path}} mode=600 owner=root group=root
+  sudo:           yes
+
+- name:           Create swapfile
+  command:        mkswap {{swap.path}}
+  sudo:           yes
+
+- name:           Enable swapfile
+  command:        swapon {{swap.path}}
+  sudo:           yes
+
+- name:           Add swapfile to /etc/fstab
+  lineinfile:     dest=/etc/fstab state=present line="{{ swap.path }}   none    swap    sw    0   0"
+  sudo:           yes
+
+- name:           Configure vm.swappiness
+  lineinfile:     dest=/etc/sysctl.conf line="vm.swappiness = {{ swap.swappiness }}" regexp="^vm.swappiness\s*?=" state=present
+  sudo:           yes
+
+- name:           Configure vm.vfs_cache_pressure
+  lineinfile:     dest=/etc/sysctl.conf line="vm.vfs_cache_pressure = {{ swap.vfs_cache_pressure }}" regexp="^vm.vfs_cache_pressure\s*?=" state=present
+  sudo:           yes
+
+- name:           Reload sysctl
+  command:        sysctl -p
+  sudo:           yes

--- a/lib/ansible/roles/common/tasks/swap.yml
+++ b/lib/ansible/roles/common/tasks/swap.yml
@@ -1,4 +1,9 @@
 ---
+- shell:          df {{ swap__path | dirname }} | awk '/^\\/dev/ {print $NF}'
+  register:       swapfile_mountpoint
+
+- debug:          var=swapfile_mountpoint
+
 - name:           Calculate ideal swapfile size
   template:       src=swapsize.j2 dest=/tmp/swapsize
 

--- a/lib/ansible/roles/common/templates/swapsize.j2
+++ b/lib/ansible/roles/common/templates/swapsize.j2
@@ -1,0 +1,20 @@
+{# determine available space on root partition #}
+{%- for mp in ansible_mounts -%}
+  {%- if mp.mount == '/' -%}
+    {%- set _disk_avail_mb = mp.size_available / 1024 / 1024 -%}
+    {# if enough space for 4x current memory, use 2x for swap #}
+    {%- if _disk_avail_mb >= (ansible_memtotal_mb * 4) -%}
+      {{ ansible_memtotal_mb * 2 }}
+    {# if enough space for 2x current memory, use 1x for swap #}
+    {%- elif _disk_avail_mb >= (ansible_memtotal_mb * 2) -%}
+      {{ ansible_memtotal_mb }}
+    {# if enough space for 1x current memory, use 1/2 for swap #}
+    {%- elif _disk_avail_mb >= ansible_memtotal_mb -%}
+      {{ ansible_memtotal_mb / 2 }}
+    {# if enough space for 1/2 current memory, use 1/4 for swap #}
+    {%- elif _disk_avail_mb >= (ansible_memtotal_mb / 2) -%}
+      {{ ansible_memtotal_mb / 4 }}
+    {%- endif -%}
+    {# otherwise leave blank, for playbook to handle #}
+  {%- endif -%}
+{%- endfor -%}

--- a/lib/ansible/roles/common/templates/swapsize.j2
+++ b/lib/ansible/roles/common/templates/swapsize.j2
@@ -2,11 +2,8 @@
 {%- for mp in ansible_mounts -%}
   {%- if mp.mount == '/' -%}
     {%- set _disk_avail_mb = mp.size_available / 1024 / 1024 -%}
-    {# if enough space for 4x current memory, use 2x for swap #}
-    {%- if _disk_avail_mb >= (ansible_memtotal_mb * 4) -%}
-      {{ ansible_memtotal_mb * 2 }}
     {# if enough space for 2x current memory, use 1x for swap #}
-    {%- elif _disk_avail_mb >= (ansible_memtotal_mb * 2) -%}
+    {%- if _disk_avail_mb >= (ansible_memtotal_mb * 2) -%}
       {{ ansible_memtotal_mb }}
     {# if enough space for 1x current memory, use 1/2 for swap #}
     {%- elif _disk_avail_mb >= ansible_memtotal_mb -%}
@@ -14,6 +11,9 @@
     {# if enough space for 1/2 current memory, use 1/4 for swap #}
     {%- elif _disk_avail_mb >= (ansible_memtotal_mb / 2) -%}
       {{ ansible_memtotal_mb / 4 }}
+    {# if enough space for 1/4 current memory, use 1/8 for swap #}
+    {%- elif _disk_avail_mb >= (ansible_memtotal_mb / 4) -%}
+      {{ ansible_memtotal_mb / 8 }}
     {%- endif -%}
     {# otherwise leave blank, for playbook to handle #}
   {%- endif -%}

--- a/lib/ansible/roles/common/templates/swapsize.j2
+++ b/lib/ansible/roles/common/templates/swapsize.j2
@@ -1,6 +1,6 @@
 {# determine available space on root partition #}
 {%- for mp in ansible_mounts -%}
-  {%- if mp.mount == '/' -%}
+  {%- if mp.mount == swapfile_mountpoint.stdout -%}
     {%- set _disk_avail_mb = mp.size_available / 1024 / 1024 -%}
     {# if enough space for 2x current memory, use 1x for swap #}
     {%- if _disk_avail_mb >= (ansible_memtotal_mb * 2) -%}

--- a/lib/yeoman/templates/ansible.cfg
+++ b/lib/yeoman/templates/ansible.cfg
@@ -5,4 +5,3 @@ private_key_file  = ./lib/ansible/files/ssh/id_rsa
 remote_user       = deploy
 roles_path        = ./bower_components/evolution-wordpress/lib/ansible/roles
 lookup_plugins    = ./bower_components/evolution-wordpress/lib/ansible/lookup_plugins
-hash_behaviour    = merge

--- a/lib/yeoman/templates/ansible.cfg
+++ b/lib/yeoman/templates/ansible.cfg
@@ -5,3 +5,4 @@ private_key_file  = ./lib/ansible/files/ssh/id_rsa
 remote_user       = deploy
 roles_path        = ./bower_components/evolution-wordpress/lib/ansible/roles
 lookup_plugins    = ./bower_components/evolution-wordpress/lib/ansible/lookup_plugins
+hash_behaviour    = merge

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -39,6 +39,6 @@ fail2ban:
   # notify_on_ban: 0
 
 swap:
-  path: /swapfile
-  swappiness: 10
-  vfs_cache_pressure: 50
+  # path: /swapfile
+  # swappiness: 10
+  # vfs_cache_pressure: 50

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -38,7 +38,6 @@ fail2ban:
   # notification_email: root@localhost
   # notify_on_ban: 0
 
-swap:
-  # path: /swapfile
-  # swappiness: 10
-  # vfs_cache_pressure: 50
+# swap__path: /swapfile
+# swap__swappiness: 10
+# swap__vfs_cache_pressure: 50

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -37,3 +37,8 @@ fail2ban:
   # ban_time: 600
   # notification_email: root@localhost
   # notify_on_ban: 0
+
+swap:
+  path: /swapfile
+  swappiness: 10
+  vfs_cache_pressure: 50


### PR DESCRIPTION
Provisioning evolution or genesis on digital ocean has resulted in mysql db crashes that I can only attribute to memory. Even with a 2Gb droplet, mysql was crapping the bed every so often with really minimal traffic, over time.

The way I "resolved" it in genesis was to add a swapfile like this:
https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-12-04

Recently deploying a 2Gb instance of evolution, I started having the same issues so I added swap to this ubutnu 14.04 vps, hoping it does the trick. Would it make sense to add a minimal (256) swap file to ansible provisioning?

Or related: have any of you had this experience? Looking through Digital Ocean support, quite a few people have wordpress/LAMP issues with mysql memory.