### PR TITLE
Use ansible defaults for role-specific settings

### DIFF
--- a/lib/ansible/roles/apache-prefork/templates/prefork.conf
+++ b/lib/ansible/roles/apache-prefork/templates/prefork.conf
@@ -1,47 +1,29 @@
-{%- if php_settings is defined and php_settings.memory_limit is defined -%}
-    {% set _memory_php = php_settings.memory_limit %}
-{%- else -%}
-    {% set _memory_php = calc_php_memory_limit.stdout %}
-{%- endif -%}
-
-{%- if reserved_memory is defined and reserved_memory.mysql is defined -%}
-    {% set _memory_mysql = reserved_memory.mysql %}
-{%- else -%}
-    {% set _memory_mysql = 512 if ansible_memtotal_mb >= 2000 else 320 %}
-{%- endif -%}
-
-{%- if reserved_memory is defined and reserved_memory.system is defined -%}
-    {% set _memory_system = reserved_memory.system %}
-{%- else -%}
-    {% set _memory_system = 512 if ansible_memtotal_mb >= 2000 else ((ansible_memtotal_mb/4) | round) %}
-{%- endif -%}
-
-{%- if apache_settings is defined and apache_settings.start_servers is defined -%}
-    {% set _apache_start_servers = apache_settings.start_servers %}
+{%- if apache__start_servers is defined -%}
+    {% set _apache_start_servers = apache__start_servers %}
 {%- else -%}
     {% set _apache_start_servers = 10 if ansible_memtotal_mb >= 2000 else 3 %}
 {%- endif -%}
 
-{%- if apache_settings is defined and apache_settings.min_spare_servers is defined -%}
-    {% set _apache_min_spare_servers = apache_settings.min_spare_servers %}
+{%- if apache__min_spare_servers is defined -%}
+    {% set _apache_min_spare_servers = apache__min_spare_servers %}
 {%- else -%}
     {% set _apache_min_spare_servers = 8 if ansible_memtotal_mb >= 2000 else 3 %}
 {%- endif -%}
 
-{%- if apache_settings is defined and apache_settings.max_spare_servers is defined -%}
-    {% set _apache_max_spare_servers = apache_settings.max_spare_servers %}
+{%- if apache__max_spare_servers is defined -%}
+    {% set _apache_max_spare_servers = apache__max_spare_servers %}
 {%- else -%}
     {% set _apache_max_spare_servers = 15 if ansible_memtotal_mb >= 2000 else 3 %}
 {%- endif -%}
 
-{%- if apache_settings is defined and apache_settings.max_requests_per_child is defined -%}
-    {% set _apache_max_requests_per_child = apache_settings.max_requests_per_child %}
+{%- if apache__max_requests_per_child is defined -%}
+    {% set _apache_max_requests_per_child = apache__max_requests_per_child %}
 {%- else -%}
     {% set _apache_max_requests_per_child = 1000 %}
 {%- endif -%}
 
-{%- if apache_settings is defined and apache_settings.max_clients is defined -%}
-    {% set _apache_max_clients = apache_settings.max_clients %}
+{%- if apache__max_clients is defined -%}
+    {% set _apache_max_clients = apache__max_clients %}
 {%- else -%}
     {%- if ansible_memtotal_mb >= 2000 -%}
         {% set _apache_max_clients = 25 -%}

--- a/lib/ansible/roles/firewall/defaults/main.yml
+++ b/lib/ansible/roles/firewall/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+iptables__ipv6: 0
+
+fail2ban__whitelist:
+  - 127.0.0.1/8
+fail2ban__ban_time: 600
+fail2ban__notification_email: root@localhost
+fail2ban__notify_on_ban: 0

--- a/lib/ansible/roles/firewall/templates/default/iptables-persistent.conf
+++ b/lib/ansible/roles/firewall/templates/default/iptables-persistent.conf
@@ -12,4 +12,4 @@ modules=""
 ENABLE_ROUTING=0
 
 # Enable IPv6? Assign to a value different that 0 if you want this enabled.
-IPV6={% if iptables.ipv6 is defined and iptables.ipv6 %}1{% else %}0{% endif %}
+IPV6={{ '1' if iptables__ipv6 else '0' }}

--- a/lib/ansible/roles/firewall/templates/fail2ban/jail.local
+++ b/lib/ansible/roles/firewall/templates/fail2ban/jail.local
@@ -3,30 +3,20 @@
 # Global definition of options, can be overridden in each jail afterwards.
 [DEFAULT]
 
-{% if fail2ban.whitelist is defined %}
 # Can be space separated IP addresses, CIDR masks or DNS hosts
-ignoreip = 127.0.0.1/8 {{ fail2ban.whitelist | join(' ') }}
+ignoreip = {{ ['127.0.0.1/8'] | union(fail2ban__whitelist) | unique | join(' ') }}
 
-{% endif %}
-{% if fail2ban.ban_time is defined %}
 # Global default ban time (in seconds)
-bantime  = {{ fail2ban.ban_time }}
+bantime  = {{ fail2ban__ban_time }}
 
-{% endif %}
-{% if fail2ban.notification_email is defined %}
 # Destination email for interpolations in jail.{conf,local}
-destemail = {{ fail2ban.notification_email }}
+destemail = {{ fail2ban__notification_email }}
 
-{% endif %}
 # Default banning action
 banaction = iptables-multiport
 
 # Default action (e.g. action_ for ban only, action_mw for ban + email, action_mwl for ban + email w relevant log entries)
-{% if fail2ban.notify_on_ban is defined and fail2ban.notify_on_ban %}
-action = %(action_mwl)s
-{% else %}
-action = %(action_)s
-{% endif %}
+action = %(action_{{ 'mwl' if fail2ban__notify_on_ban else '' }})s
 
 
 [ssh]

--- a/lib/ansible/roles/mail/templates/aliases
+++ b/lib/ansible/roles/mail/templates/aliases
@@ -1,3 +1,3 @@
 # See man 5 aliases for format
 postmaster: deploy
-deploy: {{ mail.postmaster }}
+deploy: {{ mail__postmaster }}

--- a/lib/ansible/roles/php/tasks/main.yml
+++ b/lib/ansible/roles/php/tasks/main.yml
@@ -26,14 +26,14 @@
   command:        echo "{{ 256 if ansible_memtotal_mb > 2048 else 128 }}"
   register:       calc_php_memory_limit
   ignore_errors:  true
-  when:           php_settings.memory_limit is undefined
+  when:           php__memory_limit is undefined
 
 - name:           Update php.ini's date.timezone
   lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*date\.timezone' line='date.timezone = "America/Chicago"'
   sudo:           yes
 
 - name:           Update php.ini's memory_limit
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php_settings.memory_limit }}M'
+  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php__memory_limit }}M'
   sudo:           yes
 
 - name:           Update php.ini's upload_max_filesize

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -12,28 +12,20 @@ mysql:
   password:     <%= props.DB_PASSWORD %>
   host:         <%= props.DB_HOST %>
 
-php_settings:
-  # memory_limit:
+# php__memory_limit:
 
-reserved_memory:
-  # mysql:
-  # system:
-apache_settings:
-  # start_servers:
-  # min_spare_servers:
-  # max_spare_servers:
-  # max_clients:
-  # max_requests_per_child:
+# apache__start_servers:
+# apache__min_spare_servers:
+# apache__max_spare_servers:
+# apache__max_clients:
+# apache__max_requests_per_child:
 
-mail:
-  postmaster: no-reply@<%= props.domain %>
+mail__postmaster: no-reply@<%= props.domain %>
 
-iptables:
-  # ipv6: 0
+# iptables__ipv6: 0
 
-fail2ban:
-  # whitelist:
-  #   - 127.0.0.1/8
-  # ban_time: 600
-  # notification_email: root@localhost
-  # notify_on_ban: 0
+# fail2ban__whitelist:
+#   - 127.0.0.1/8
+# fail2ban__ban_time: 600
+# fail2ban__notification_email: root@localhost
+# fail2ban__notify_on_ban: 0


### PR DESCRIPTION
Our existing roles should make use of ansible's built in [role defaults](http://docs.ansible.com/ansible/playbooks_roles.html#role-default-variables) when applicable, instead of our current "check if the override variable is defined and otherwise fill in the blank" approach.

* in the `firewall` role, [customizing ipv6 and fail2ban settings](https://github.com/evolution/wordpress/blob/722c5b7bb51b7826ca380ff19b2f9e325305e595/lib/yeoman/templates/lib/ansible/group_vars/all#L31-L39) vs [defaulting them in the generated files](https://github.com/evolution/wordpress/blob/722c5b7bb51b7826ca380ff19b2f9e325305e595/lib/ansible/roles/firewall/templates/fail2ban/jail.local#L6-L25)

Even where static defaults are not applicable, we should switch out nested dicts of variables with prefixed strings -- otherwise, overriding one item in a dict gets very messy. The following roles use dynamic defaults, calculated during provisioning.

* in the `php` role, [setting a custom memory limit](https://github.com/evolution/wordpress/blob/722c5b7bb51b7826ca380ff19b2f9e325305e595/lib/yeoman/templates/lib/ansible/group_vars/all#L15-L16) vs [calculating a default](https://github.com/evolution/wordpress/blob/722c5b7bb51b7826ca380ff19b2f9e325305e595/lib/ansible/roles/php/tasks/main.yml#L25-L37)
* in the `apache-prefork` role, [explicitly tuning prefork settings](https://github.com/evolution/wordpress/blob/722c5b7bb51b7826ca380ff19b2f9e325305e595/lib/yeoman/templates/lib/ansible/group_vars/all#L18-L26) vs [a fustercluck of if...elses](https://github.com/evolution/wordpress/blob/722c5b7bb51b7826ca380ff19b2f9e325305e595/lib/ansible/roles/apache-prefork/templates/prefork.conf#L1-L53) (many of which _are no longer even being used_)

Note the proper implementation of role defaults for swapfile customization in #83 