### PR TITLE
Regexp tweaks for existing README in generator

### DIFF
--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -467,8 +467,8 @@ var WordpressGenerator = yeoman.generators.Base.extend({
     try {
       this.readmeFile = this.readFileAsString(path.join(this.env.cwd, 'README.md'));
       this.readmeFile = this.readmeFile
-        .replace(/^(?:\[[^\]]+\]){1,2}(?:\([^\)]+\))?[\r\n]+=+[\r\n]+> Powered by \[(?:Genesis|Evolution)[^\r\n]+[\r\n]+/i, '')
-        .replace(/\[[^\]]+\]:\s*http[^\r\n]+[\r\n]+\[(?:genesis|evolution)-wordpress\]:\s*http[^\r\n]+[\r\n]*$/i, '')
+        .replace(/^(?:\[[^\]\r\n]+\]){1,2}(?:\([^\)\r\n]+\))?[\r\n]+=+[\r\n]+> Powered by \[(?:Genesis|Evolution)[^\r\n]+[\r\n]+/i, '')
+        .replace(/[\r\n]\[[^\]\r\n]+\]:\s*http[^\r\n]+[\r\n]+\[(?:genesis|evolution)-wordpress\]:\s*http[^\r\n]+[\r\n]*$/i, '')
       ;
     } catch(e) {
       this.readmeFile = '';


### PR DESCRIPTION
The existing regexp was potentially catching custom content that contained an opening bracket `[`. This ensures we _only_ match the markdown links created by the generator at the tail end of the readme.

Reported by @ericrasch