### PR TITLE
Ansible fails at swap stage

### DIFF
--- a/lib/ansible/roles/common/tasks/swap.yml
+++ b/lib/ansible/roles/common/tasks/swap.yml
@@ -1,5 +1,5 @@
 ---
-- shell:          df {{ swap__path | dirname }} | awk '/^\\/dev/ {print $NF}'
+- shell:          "df {{ swap__path | dirname }} | awk '!/^Filesystem/ {print $NF}'"
   register:       swapfile_mountpoint
 
 - debug:          var=swapfile_mountpoint


### PR DESCRIPTION
I'm attempting to create a fresh project but it fails at the swap stage each time. I've tried nuking everything and starting from scratch several times. Any idea where I'm going wrong?

```
TASK: [common | shell df {{ swap__path | dirname }} | awk '/^\\/dev/ {print $NF}'] ***
failed: [local.example.com] => {"changed": true, "cmd": "df / | awk '/^\\\\/dev/ {print $NF}'", "delta": "0:00:00.005089", "end": "2015-10-16 01:11:18.932743", "rc": 1, "start": "2015-10-16 01:11:18.927654", "warnings": []}
stderr: awk: cmd. line:1: /^\\/dev/ {print $NF}
awk: cmd. line:1:           ^ syntax error

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/Users/user/provision.retry

local.example.com : ok=11   changed=1    unreachable=0    failed=1

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

sshpass 1.05
ansible 1.9.4
Vagrant 1.7.4
node v0.12.7