### PR TITLE
Could not find dependencies that are installed

### DIFF
--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -73,7 +73,7 @@ var WordpressGenerator = yeoman.generators.Base.extend({
       this.emit('dependencyCheck'+dependency);
 
       this
-        .spawnCommand('command', ['-v', dependency], {cwd: this.env.cwd, env: process.env})
+        .spawnCommand('which', [dependency], {cwd: this.env.cwd, env: process.env})
         .on('error', exited.bind(this, dependency))
         .on('exit', this.emit.bind(this, 'dependencyCheck'+dependency+':end'))
         .on('exit', exited.bind(this, dependency))


### PR DESCRIPTION
I'm running Ubuntu 15.04, Node 0.12.3, and npm 2.14.0 and got the error of "could not find dependencies" for sshpass, bundler, ansible, bower, and npm.

The thing is, the previous part of the `yo evolve wordpress` process installed all of the NPM dependencies. I checked and bundler works (I use it with WP genesis), ansible is there too, sshpass comes up, NPM obviously works, and bower works too. At least from the command line.

Is there any reason why it'd fail on this part despite having all of the dependencies installed?