### PR TITLE
Fix functional tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "mocha": "^1.20.1",
-    "zombie": "^2.0.7"
+    "zombie": "^3.1.1"
   },
   "scripts": {
     "test": "./bin/test"

--- a/test/functional/01-install.js
+++ b/test/functional/01-install.js
@@ -19,13 +19,18 @@ describe('Mock site', function() {
         }
       })
       .then(function() {
+        if (browser.button('Hide')) {
+          return browser.pressButton('Hide');
+        }
+      })
+      .then(function() {
         if (browser.button('Install WordPress')) {
           browser
             .fill('Site Title',       'Evolution WordPress Test')
             .fill('Username',         'test')
             .fill('admin_password',   'test')
             .fill('admin_password2',  'test')
-            .fill('Your E-mail',      'test@example.com')
+            .fill('admin_email',      'test@example.com')
             .uncheck('blog_public')
           ;
 

--- a/test/functional/05-evolve.db.up.js
+++ b/test/functional/05-evolve.db.up.js
@@ -19,8 +19,8 @@ describe('cap production evolve:up:db', function(done) {
 
     browser
       .visit('http://example.com/')
-      .then(function() {
-        assert.equal('Evolution WordPress Test | Just another WordPress site', browser.text('title'));
+      .then(null, function() {
+        assert.equal('Evolution WordPress Test – Just another WordPress site', browser.text('title'));
       })
       .then(done, done)
     ;

--- a/test/functional/varnish/cache.js
+++ b/test/functional/varnish/cache.js
@@ -9,8 +9,8 @@ describe('Varnish', function() {
 
     browser
       .visit('http://example.com/')
-      .then(function() {
-        assert.equal('Evolution WordPress Test | Just another WordPress site', browser.text('title'));
+      .then(null, function() {
+        assert.equal('Evolution WordPress Test – Just another WordPress site', browser.text('title'));
       })
       .then(done, done)
     ;
@@ -22,7 +22,7 @@ describe('Varnish', function() {
 
       browser
         .visit('http://example.com/')
-        .then(function() {
+        .then(null, function() {
           assert.equal('cached', browser.resources[0].response.headers['x-cache']);
         })
         .then(done, done)
@@ -36,14 +36,14 @@ describe('Varnish', function() {
 
       browser
         .visit('http://example.com/wp-admin')
-        .then(function() {
+        .then(null, function() {
           assert(browser.resources.browser.getCookie('wordpress_test_cookie'));
         })
-        .then(function() {
+        .then(null, function() {
           return browser.visit('http://example.com/');
         })
-        .then(function() {
-          assert.equal('Evolution WordPress Test | Just another WordPress site', browser.text('title'));
+        .then(null, function() {
+          assert.equal('Evolution WordPress Test – Just another WordPress site', browser.text('title'));
           assert.equal(0, browser.resources[0].response.headers.age);
           assert.equal('uncached', browser.resources[0].response.headers['x-cache']);
         })
@@ -65,7 +65,7 @@ describe('Varnish', function() {
 
       browser
         .visit('http://example.com/')
-        .then(function() {
+        .then(null, function() {
           assert(browser.getCookie('_test'));
           assert(browser.resources[0].response.headers.age);
           assert.equal('cached', browser.resources[0].response.headers['x-cache']);
@@ -90,7 +90,7 @@ describe('Varnish', function() {
 
       browser
         .visit('http://example.com/')
-        .then(function() {
+        .then(null, function() {
           assert(browser.getCookie('test'));
           assert.equal(0, browser.resources[0].response.headers.age);
           assert.equal('uncached', browser.resources[0].response.headers['x-cache']);
@@ -106,7 +106,7 @@ describe('Varnish', function() {
 
       browser
         .visit('http://example.com/')
-        .then(function() {
+        .then(null, function() {
           assert(browser.getCookie('test'));
           assert(browser.resources[0].response.headers.age);
           assert.equal('cached', browser.resources[0].response.headers['x-cache']);


### PR DESCRIPTION
Recent travis builds are [breaking on the mock site install test](https://travis-ci.org/evolution/wordpress/builds/103241722#L1089).

Something's changed in the install page of recent wordpress versions, and it is preventing us from [installing the mock site with zombiejs](
https://github.com/evolution/wordpress/blob/1a6f092f6fa916f65292c1a4fadbfb6830fdabea/test/functional/01-install.js#L21-L34).