### PR TITLE
Tune apache logrotate settings

### DIFF
--- a/lib/ansible/roles/apache/tasks/main.yml
+++ b/lib/ansible/roles/apache/tasks/main.yml
@@ -22,6 +22,10 @@
 
 - debug:          msg={{ apache_version.stdout }}
 
+- name:           Configure apache logrotate
+  template:       src=logrotate dest=/etc/logrotate.d/apache2 mode=0644
+  sudo:           yes
+
 - name:           Configure Apache canonical server name (2.2)
   template:       src=canonical dest=/etc/apache2/conf.d/canonical-servername.conf mode=0644
   notify:         restart apache

--- a/lib/ansible/roles/apache/templates/logrotate
+++ b/lib/ansible/roles/apache/templates/logrotate
@@ -1,0 +1,20 @@
+/var/log/apache2/*.log {
+	size 100M
+	missingok
+	rotate 10
+	compress
+	delaycompress
+	notifempty
+	create 640 root adm
+	sharedscripts
+	postrotate
+                if /etc/init.d/apache2 status > /dev/null ; then \
+                    /etc/init.d/apache2 reload > /dev/null; \
+                fi;
+	endscript
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi; \
+	endscript
+}


### PR DESCRIPTION
Currently, we're using the ubuntu stock logrotate config for apache logs: a weekly rotate, keeping the last 52 gzipped rotations.

In the event of sudden large surges of traffic, this has been known to fill disks. We should rotate upon reaching a given filesize instead, and perhaps not keep so many old rotations