### PR TITLE
Ensure latest version of wp-cli on reprovision

### DIFF
--- a/lib/ansible/roles/wp-cli/tasks/main.yml
+++ b/lib/ansible/roles/wp-cli/tasks/main.yml
@@ -3,4 +3,5 @@
     url:      https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
     dest:     /usr/local/bin/wp
     mode:     0755
+    force:    yes
   sudo:       true


### PR DESCRIPTION
There's a [known compatibility issue](http://wp-cli.org/blog/versions-0.21.1-and-0.20.4.html) with Wordpress 4.4 and wp-cli prior to 0.20.4.

When reprovisioning an existing server, [we are not currently replacing the existing wp-cli](https://github.com/evolution/wordpress/blob/master/lib/ansible/roles/wp-cli/tasks/main.yml), thus causing issues when upgrading an existing evolution site to wp 4.4 and on.

To remedy this, we should be using the [`force` option of ansible's `get_url` module](http://docs.ansible.com/ansible/get_url_module.html).