### PR TITLE
Test for (and clean up) full `/boot` partitions

### DIFF
--- a/lib/ansible/roles/common/tasks/main.yml
+++ b/lib/ansible/roles/common/tasks/main.yml
@@ -14,6 +14,7 @@
     dest:         /tmp/purge-kernels.py
     mode:         0755
     force:        yes
+  sudo:           yes
 
 - name:           Purge kernels as necessary
   command:        /tmp/purge-kernels.py

--- a/lib/ansible/roles/common/tasks/main.yml
+++ b/lib/ansible/roles/common/tasks/main.yml
@@ -20,6 +20,7 @@
   register:       purgekernels_result
   ignore_errors:  yes
   sudo:           yes
+  when:           not lookup('env','CI')
 
 - name:           Show purged kernels
   debug:          var=purgekernels_result

--- a/lib/ansible/roles/common/tasks/main.yml
+++ b/lib/ansible/roles/common/tasks/main.yml
@@ -8,6 +8,22 @@
 - name:           New Hostname
   debug:          var=new_hostname
 
+- name:           Fetch kernel purging script
+  get_url:
+    url:          https://raw.githubusercontent.com/EvanK/ubuntu-purge-kernels/master/purge-kernels.py
+    dest:         /tmp/purge-kernels.py
+    mode:         0755
+    force:        yes
+
+- name:           Purge kernels as necessary
+  command:        /tmp/purge-kernels.py
+  register:       purgekernels_result
+  ignore_errors:  yes
+  sudo:           yes
+
+- name:           Show purged kernels
+  debug:          var=purgekernels_result
+
 - name:           Update apt cache
   apt:            update_cache=yes cache_valid_time="{{ 60 * 60 * 24 }}"
   sudo:           yes


### PR DESCRIPTION
This is an edge case, but one that we've run into repeatedly with vcenter servers.

Before running an [apt autoremove](https://github.com/evolution/wordpress/blob/a08a5374233f540ae3458657fc92118c45ba5550/lib/ansible/roles/common/tasks/main.yml#L15-L17), we should test if (1) a `/boot` partition exists and (2) it's full...and if it is, [do some purging of older kernels](https://github.com/EvanK/ubuntu-purge-kernels).