### PR TITLE
Confirm or bypass git protocol support

### DIFF
--- a/lib/ansible/roles/common/tasks/main.yml
+++ b/lib/ansible/roles/common/tasks/main.yml
@@ -35,5 +35,14 @@
   copy:           src=logrotate dest=/etc/logrotate.d/evolution mode=0644
   sudo:           yes
 
+- name:           Test for git protocol (git://) connectivity
+  command:        curl -v -m 10 http://github.com:9418/
+  register:       git_protocol_test
+  ignore_errors:  true
+
+- name:           Bypass git protocol if necessary
+  command:        git config --global url."https://".insteadOf git://
+  when:           "'connect() timed out' in git_protocol_test.stderr"
+
 - include:        swap.yml
   when:           ansible_swaptotal_mb == 0


### PR DESCRIPTION
Behind restrictive networks (Rackspace Cloud, for instance), [the `git://` protocol](https://git-scm.com/book/ch4-1.html#The-Git-Protocol) _may_ not be usable, and some unauthenticated git operations (including bower installations) may fail.

This will test whether that protocol's port is open, and if it's not, configure git (for the `deploy` user) to substitute `https://` in its place.

**Note:** this fix should be backported into genesis