### PR TITLE
Refactored travis testing under Trusty

### DIFF
--- a/.travis.provision.bin
+++ b/.travis.provision.bin
@@ -7,15 +7,5 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
-# Ansible dependencies
-apt-get -qq -y update
-apt-get -qq -y install python-software-properties software-properties-common python-pycurl
-
-add-apt-repository -y ppa:rquillo/ansible &> /dev/null || exit 1
-apt-get -qq -y update
-
-# Ansible
-apt-get -qq -y install ansible
-
 # Run provisioning playbook
-(cd "$( dirname "$0" )/../temp" && ansible-playbook lib/ansible/provision.yml --connection=local -e stage=local)
+(cd /vagrant && ansible-playbook lib/ansible/provision.yml --connection=local -e stage=local)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: node_js
-node_js:
-  - "0.10"
+sudo: required
+dist: trusty
+language: generic
 addons:
   hosts:
     - example.com
@@ -8,30 +8,45 @@ addons:
     - production.example.com
     - www.example.com
 before_install:
-  - rvm use 1.9.3
-  - gem install bundler
-  - echo "Install NPM dependencies"
+  # node setup (for yeoman/bower)
+  - nvm install 0.10
+  - node --version
+  - npm --version
+  - nvm --version
   - npm install -g bower
   - npm install
-  - echo "Mock test project"
+  # ruby setup (for capistrano)
+  - rvm use 1.9.3
+  - gem install bundler
+  - ruby --version
+  - rvm --version
+  - gem --version
+  - bundle --version
+  # python setup (for ansible)
+  - sudo pip install ansible==1.9.4
+  - python --version
+  - pip --version
+  - ansible --version
+  # mock up test project, and move to /vagrant for end-user tests
   - $PWD/bin/mock
-  - echo "Move mock project to /vagrant for end-user tests"
   - sudo mv $PWD/temp /vagrant
   - ln -s /vagrant $PWD/temp
-  - echo "Copying local Evolution WordPress as dependency"
+  # copy our local evolution-wordpress as bower dependency
   - rm -rf /vagrant/bower_components/evolution-wordpress
   - cp -RP $PWD /vagrant/bower_components/evolution-wordpress/
-  - echo "Provision server"
+  # invoke local provision (as default user with elevated permissions)
   - sudo cp $PWD/.travis.provision.bin $PWD/bin/provision
   - sudo chmod +x $PWD/bin/provision
   - sudo $PWD/bin/provision
   - sudo chown -Rf $USER:$USER $HOME/.ansible
-  - echo "Mocking vagrant binary"
+  # mock vagrant binary (for parity with local/remote stages)
   - sudo cp $PWD/.travis.vagrant.bin /bin/vagrant
   - sudo chmod +x /bin/vagrant
+  # ensure known ssh fingerprints for remote stages
   - ssh-keyscan -H production.example.com >> $HOME/.ssh/known_hosts
   - ssh-keyscan -H www.example.com >> $HOME/.ssh/known_hosts
   - ssh-keyscan -H example.com >> $HOME/.ssh/known_hosts
+  # install composer (for phpunit)
   - curl -sS https://getcomposer.org/installer | php
 install:
   - echo "Install Composer dependencies"

--- a/lib/ansible/roles/mysql/tasks/main.yml
+++ b/lib/ansible/roles/mysql/tasks/main.yml
@@ -17,5 +17,5 @@
   sudo:           yes
 
 - name:           Create MySQL user
-  mysql_user:     name={{ mysql.user }} host={{ mysql.host }} password={{ mysql.password }} priv="{{ mysql.name }}_{{ stage }}".*:GRANT,ALL append_privs=yes
+  mysql_user:     name={{ mysql.user }} host={{ mysql.host }} password={{ mysql.password }} priv="{{ mysql.name }}_{{ stage }}.*:GRANT,ALL" append_privs=yes
   sudo:           yes

--- a/lib/ansible/roles/php-hardened/tasks/main.yml
+++ b/lib/ansible/roles/php-hardened/tasks/main.yml
@@ -4,4 +4,3 @@
   sudo:           yes
 
 - include:        suhosin.yml
-  when:           lookup('env','TRAVIS') != 'true'


### PR DESCRIPTION
Using a Trusty Tahir (14.04) image that gives us a more accurate testing platform, since that's what evolution builds on already.

**Note:** we're using ansible 1.9 for testing because 2.0 _completely_ changed plugin api, breaking [our nested_dict lookup](https://github.com/evolution/wordpress/blob/db54ee6ff86e035d3fb40abb14ff571a92049cfd/lib/ansible/lookup_plugins/nested_dict.py). I've rewritten it for 2.0 (see ansible/ansible#9563), but that breaks backward compatibility with ansible 1, so I want to move the bc break to a minor version release (targeting `1.4`) with other updated dependencies.