### PR TITLE
Varnish expanded ESI support

### DIFF
--- a/lib/ansible/roles/varnish/files/etc-varnish/production.vcl
+++ b/lib/ansible/roles/varnish/files/etc-varnish/production.vcl
@@ -1,5 +1,6 @@
 # Default backend definition.  Set this to point to your content server.
 # all paths relative to varnish option vcl_dir
+import std;
 
 include "custom.backend.vcl";
 include "custom.acl.vcl";
@@ -216,6 +217,10 @@ sub vcl_fetch {
 
     # Parse ESI request and remove Surrogate-Control header
     if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
+        # Honor max-age, if provided, from Surrogate-Control
+        if (beresp.http.Surrogate-Control ~ "max-age=\d+[smhdw]?") {
+            set beresp.ttl = std.duration(regsub(beresp.http.Surrogate-Control, "^.*?max-age=(\d+[smhdw]?).*?$", "\1"), beresp.ttl);
+        }
         unset beresp.http.Surrogate-Control;
         set beresp.do_esi = true;
     }


### PR DESCRIPTION
### What we've got
Currently, we (sort of) support [edge side includes](https://www.varnish-cache.org/docs/3.0/tutorial/esi.html) in our vcl configuration...but only when [the backend response](https://github.com/evolution/wordpress/blob/924760a175ad28b3b3f006132b0ca94cae35ee0f/lib/ansible/roles/varnish/files/etc-varnish/production.vcl#L217-L221) includes a particular `Surrogate-Control` header.

Per [the W3C spec](https://www.w3.org/TR/edge-arch/), the aforementioned header also supports an explicit `max-age` directive, and this would be useful for letting each edge side included file determine its own cache ttl.

### What we want
The functionality I have in mind would include two pieces:

1. A response from the Apache backend should _only_ be parsed for includes when it has a `Surrogate-Control` header containing `"ESI/1.0"`
2. A page being included at the edge side should be able to set its own cache ttl by sending a `Surrogate-Control` header with a `max-age` directive [in the format of a varnish duration](https://www.varnish-cache.org/docs/3.0/reference/vmod_std.html#duration)

### Proof of concept
This should be readily testable with a couple of php files outside wordpress. The first would be hit directly, and include another file:
```php
<?php # /foo.php
header('Surrogate-Control: content="ESI/1.0"');
# we should be cached as long as any other content
?>
<esi:remove><div>If you're seeing this, we are NOT doing edge side includes!</div></esi:remove>
<div>Wrapping page: <?php echo date('r'); ?></div>
<div><!--esi <esi:include src="bar.php"/> --></div>
```

The second would be the file included, that sets its own ttl:
```php
<?php # /bar.php
header('Surrogate-Control: max-age=10s; content="ESI/1.0"');
# we should be cached for no longer than 10 seconds
?>
Wrapped include: <?php echo date('r'); ?>
```