### PR TITLE
WP Cron support

### DIFF
--- a/lib/ansible/roles/cleanup/tasks/main.yml
+++ b/lib/ansible/roles/cleanup/tasks/main.yml
@@ -10,9 +10,9 @@
   cron:
   args:
     name:       "wpcron for {{stage}}"
-    user:       "{{item.value.user}}"
-    job:        "cd {{item.value.path}} && /usr/local/bin/wp core is-installed --path=$PWD --url='http://{{stage}}.{{domain}}/' && /usr/local/bin/wp cron event run --all --quiet --path=$PWD --url='http://{{stage}}.{{domain}}/'"
-  with_dict:    wp_cron
+    user:       deploy
+    job:        "cd {{item.value}} && /usr/local/bin/wp core is-installed --path=$PWD --url='http://{{stage}}.{{domain}}/' && /usr/local/bin/wp cron event run --all --quiet --path=$PWD --url='http://{{stage}}.{{domain}}/'"
+  with_dict:    wp_cron_path
   when:         item.key == stage
 
 - name:         Generate init.d for installed evolution services

--- a/lib/ansible/roles/cleanup/tasks/main.yml
+++ b/lib/ansible/roles/cleanup/tasks/main.yml
@@ -11,7 +11,7 @@
   args:
     name:       "wpcron for {{stage}}"
     user:       "{{item.value.user}}"
-    job:        "cd {{item.value.path}} && /usr/local/bin/wp core is-installed --path=$PWD --url='{{item.value.url}}' && /usr/local/bin/wp cron event run --all --quiet --path=$PWD --url='{{item.value.url}}'"
+    job:        "cd {{item.value.path}} && /usr/local/bin/wp core is-installed --path=$PWD --url='http://{{stage}}.{{domain}}/' && /usr/local/bin/wp cron event run --all --quiet --path=$PWD --url='http://{{stage}}.{{domain}}/'"
   with_dict:    wp_cron
   when:         item.key == stage
 

--- a/lib/ansible/roles/cleanup/tasks/main.yml
+++ b/lib/ansible/roles/cleanup/tasks/main.yml
@@ -6,6 +6,15 @@
     removes:    /etc/cron.daily/logrotate
   sudo:         yes
 
+- name:         Set up wpcron via user-level crontab
+  cron:
+  args:
+    name:       "wpcron for {{stage}}"
+    user:       "{{item.value.user}}"
+    job:        "cd {{item.value.path}} && /usr/local/bin/wp core is-installed --path=$PWD --url='{{item.value.url}}' && /usr/local/bin/wp cron event run --all --quiet --path=$PWD --url='{{item.value.url}}'"
+  with_dict:    wp_cron
+  when:         item.key == stage
+
 - name:         Generate init.d for installed evolution services
   template:     src=evolution-init-d dest=/etc/init.d/evolution-wordpress mode=0755
   sudo:         yes

--- a/lib/ansible/roles/cleanup/tasks/main.yml
+++ b/lib/ansible/roles/cleanup/tasks/main.yml
@@ -14,6 +14,7 @@
     job:        "cd {{item.value}} && /usr/local/bin/wp core is-installed --path=$PWD --url='http://{{stage}}.{{domain}}/' && /usr/local/bin/wp cron event run --all --quiet --path=$PWD --url='http://{{stage}}.{{domain}}/'"
   with_dict:    wp_cron_path
   when:         item.key == stage
+  sudo:         yes
 
 - name:         Generate init.d for installed evolution services
   template:     src=evolution-init-d dest=/etc/init.d/evolution-wordpress mode=0755

--- a/lib/ansible/roles/cleanup/vars/main.yml
+++ b/lib/ansible/roles/cleanup/vars/main.yml
@@ -3,12 +3,9 @@ wp_cron:
   local:
     user: vagrant
     path: /vagrant/web/wp
-    url: "http://{{stage}}.{{domain}}/"
   staging:
     user: deploy
     path: "/var/www/{{domain}}/staging/*/current/wp"
-    url: "http://{{stage}}.{{domain}}/"
   production:
     user: deploy
     path: "/var/www/{{domain}}/production/master/current/wp"
-    url: "http://{{stage}}.{{domain}}/"

--- a/lib/ansible/roles/cleanup/vars/main.yml
+++ b/lib/ansible/roles/cleanup/vars/main.yml
@@ -1,0 +1,14 @@
+---
+wp_cron:
+  local:
+    user: vagrant
+    path: /vagrant/web/wp
+    url: "http://{{stage}}.{{domain}}/"
+  staging:
+    user: deploy
+    path: "/var/www/{{domain}}/staging/*/current/wp"
+    url: "http://{{stage}}.{{domain}}/"
+  production:
+    user: deploy
+    path: "/var/www/{{domain}}/production/master/current/wp"
+    url: "http://{{stage}}.{{domain}}/"

--- a/lib/ansible/roles/cleanup/vars/main.yml
+++ b/lib/ansible/roles/cleanup/vars/main.yml
@@ -1,11 +1,5 @@
 ---
-wp_cron:
-  local:
-    user: vagrant
-    path: /vagrant/web/wp
-  staging:
-    user: deploy
-    path: "/var/www/{{domain}}/staging/*/current/wp"
-  production:
-    user: deploy
-    path: "/var/www/{{domain}}/production/master/current/wp"
+wp_cron_path:
+  local: /vagrant/web/wp
+  staging: "/var/www/{{domain}}/staging/*/current/wp"
+  production: "/var/www/{{domain}}/production/master/current/wp"


### PR DESCRIPTION
Wordpress comes with an internal system for running scheduled jobs (WP-Cron), and [it sucks](https://www.lucasrolff.com/wordpress/why-wp-cron-sucks/).

We are already [disabling WP-Cron in our wordpress config template](https://github.com/evolution/wordpress/blob/698c3ef45ff6dd5ee6ad9cb0fe5433f6c00f8b3e/lib/yeoman/templates/web/wp-config.php#L33), thus avoiding the extra load and processing on every webserver request.

In the interest of supporting any plugins or themes that leverage it, we should implement a system cron replacement. I'm thinking an entry in `deploy`'s crontab for each provisioned stage should do nicely.

We could hit the webserver directly via curl (bypassing varnish entirely):
> `curl -ks -H "Host: local.example.com" http://127.0.0.1:8080/wp-cron.php`

Or, we could leverage wp-cli:
> `bundle exec cap local wp:cron:event:run:--all:--quiet`
