### PR TITLE
Support ansible 1 and 2

### DIFF
--- a/lib/ansible/lookup_plugins/ansible1_nested_dict.py
+++ b/lib/ansible/lookup_plugins/ansible1_nested_dict.py
@@ -1,0 +1,47 @@
+# (c) 2014, Evan Kaufman <ekaufman@digitalflophouse.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.utils import safe_eval
+import ansible.utils as utils
+import ansible.errors as errors
+
+def flatten_nested_hash_to_list(terms, result=None, stack=None, level=None):
+    result = [] if result is None else result
+    stack = {} if stack is None else stack
+    level = 0 if level is None else level
+
+    for key, val in terms.iteritems():
+        stack['key_%s' % level] = key
+        if type(val) is dict:
+            flatten_nested_hash_to_list(terms=val, result=result, stack=stack.copy(), level=level+1)
+        else:
+            stack['value'] = val
+            result.append(stack.copy())
+    return result
+
+class LookupModule(object):
+
+    def __init__(self, basedir=None, **kwargs):
+        self.basedir = basedir
+
+    def run(self, terms, inject=None, **kwargs):
+        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
+
+        if not isinstance(terms, dict):
+            raise errors.AnsibleError("with_nested_dict expects a dict")
+
+        return flatten_nested_hash_to_list(terms)

--- a/lib/ansible/lookup_plugins/ansible2_nested_dict.py
+++ b/lib/ansible/lookup_plugins/ansible2_nested_dict.py
@@ -1,0 +1,84 @@
+# (c) 2016, Evan Kaufman <ekaufman@digitalflophouse.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+"""
+Lookup plugin to flatten nested dictionaries for linear iteration
+=================================================================
+
+For example, a collection of holidays nested by year, month, and day:
+
+    {
+        '2016': {
+            'January': {
+                '1':  'New Years Day',
+                '19': 'Martin Luther King Day',
+            },
+            'February': {
+                '14': 'Valentines Day',
+                '16': 'Presidents Day',
+            },
+            ...
+        },
+        ...
+    }
+
+Would be flattened into an array of shallow dicts, with each original key denoted by its nesting level:
+
+    [
+        { 'key_0': '2016', 'key_1': 'January',  'key_2': '1',  'value': 'New Years Day' },
+        { 'key_0': '2016', 'key_1': 'January',  'key_2': '19', 'value': 'Martin Luther King Day' },
+        { 'key_0': '2016', 'key_1': 'February', 'key_2': '14', 'value': 'Valentines Day' },
+        { 'key_0': '2016', 'key_1': 'February', 'key_2': '16', 'value': 'Presidents Day' },
+        ...
+    ]
+
+The nested keys and value of each are then exposed to an iterative task:
+
+    - name:               "Remind us what holidays are this month"
+      debug:
+        msg:              "Remember {{value}} on {{key_1}} {{'%02d'|format(key_2)}} in the year {{key_0}}"
+      when:               key_1 == current_month
+      with_nested_dict:   holidays_by_year_month_day
+
+"""
+class LookupModule(LookupBase):
+
+    @staticmethod
+    def _flatten_nested_hash_to_list(terms, result=None, stack=None, level=None):
+        result = [] if result is None else result
+        stack = {} if stack is None else stack
+        level = 0 if level is None else level
+
+        for key, val in terms.iteritems():
+            stack['key_%s' % level] = key
+            if type(val) is dict:
+                LookupModule._flatten_nested_hash_to_list(terms=val, result=result, stack=stack.copy(), level=level+1)
+            else:
+                stack['value'] = val
+                result.append(stack.copy())
+        return result
+
+    def run(self, terms, variables=None, **kwargs):
+        if not isinstance(terms, dict):
+            raise AnsibleError("with_nested_dict expects a dict")
+
+        return self._flatten_nested_hash_to_list(terms)

--- a/lib/ansible/lookup_plugins/nested_dict.py
+++ b/lib/ansible/lookup_plugins/nested_dict.py
@@ -1,47 +1,11 @@
-# (c) 2014, Evan Kaufman <ekaufman@digitalflophouse.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# add current dir to import path
+import sys
+import os
+sys.path.append(os.path.dirname(__file__))
 
-from ansible.utils import safe_eval
-import ansible.utils as utils
-import ansible.errors as errors
-
-def flatten_nested_hash_to_list(terms, result=None, stack=None, level=None):
-    result = [] if result is None else result
-    stack = {} if stack is None else stack
-    level = 0 if level is None else level
-
-    for key, val in terms.iteritems():
-        stack['key_%s' % level] = key
-        if type(val) is dict:
-            flatten_nested_hash_to_list(terms=val, result=result, stack=stack.copy(), level=level+1)
-        else:
-            stack['value'] = val
-            result.append(stack.copy())
-    return result
-
-class LookupModule(object):
-
-    def __init__(self, basedir=None, **kwargs):
-        self.basedir = basedir
-
-    def run(self, terms, inject=None, **kwargs):
-        terms = utils.listify_lookup_plugin_terms(terms, self.basedir, inject)
-
-        if not isinstance(terms, dict):
-            raise errors.AnsibleError("with_nested_dict expects a dict")
-
-        return flatten_nested_hash_to_list(terms)
+# import the right plugin for the right ansible major version
+from ansible import __version__ as ansible_version
+if ansible_version.startswith('2.'):
+    from ansible2_nested_dict import LookupModule
+elif ansible_version.startswith('1.'):
+    from ansible1_nested_dict import LookupModule


### PR DESCRIPTION
The [nested_dict lookup plugin](https://github.com/evolution/wordpress/blob/698c3ef45ff6dd5ee6ad9cb0fe5433f6c00f8b3e/lib/ansible/lookup_plugins/nested_dict.py) we provide no longer works as of Ansible 2 -- see [the 2.0 porting guide](https://docs.ansible.com/ansible/porting_guide_2.0.html#porting-plugins).

Good news is, [I've already updated it for _our_ 2.0 branch](https://github.com/evolution/wordpress/blob/778ecf2e1c74e7a0132203d93a2cf6134b7442b3/lib/ansible/lookup_plugins/nested_dict.py). I just need to check ansible's internal version, and import the proper `nested_dict` plugin for the running ansible version :neckbeard: 