### PR TITLE
Tweaks for cambrian + particularly large site imports

### DIFF
--- a/bin/import
+++ b/bin/import
@@ -128,12 +128,12 @@ var cpExec = deasync(cp.exec);
 var capCmd = 'bundle exec cap local evolve:db:exec[' + path.join(extractedPath, 'wordpress.sql') + ']';
 
 console.log('importing sql via:', chalk.cyan(capCmd));
-cpExec(capCmd, {cwd: siteDirectory, env: util._extend(process.env, {evolution_non_interactive: 1}), stdio: 'inherit'});
+cpExec(capCmd, {cwd: siteDirectory, env: util._extend(process.env, {evolution_non_interactive: 1}), stdio: 'inherit', maxBuffer: 1024*1024});
 
 // list all users via wp-cli
 capCmd = 'bundle exec cap local wp:user:list:--fields=ID,user_login,roles:--format=json';
 console.log('listing users via:', chalk.cyan(capCmd));
-var capOut = cpExec(capCmd, {cwd: siteDirectory, env: process.env, stdio: 'inherit'});
+var capOut = cpExec(capCmd, {cwd: siteDirectory, env: process.env, stdio: 'inherit', maxBuffer: 1024*1024});
 
 // prompt for role of any users lacking one
 var existingUsers = capOut.match(/\s+(\[\{"ID":[^\r\n]+)/);

--- a/lib/yeoman/templates/README.md
+++ b/lib/yeoman/templates/README.md
@@ -4,5 +4,5 @@
 > Powered by [Evolution WordPress][evolution-wordpress] *v<%= pkg.version %>*
 
 <%= readmeFile %>
-[<%= props.domain %>]: http://<%= props.domain %>/
+[<%= props.domain %>]: http://<%= props.www ? 'www.' : '' %><%= props.domain %>/
 [evolution-wordpress]: https://github.com/evolution/wordpress/


### PR DESCRIPTION
Found some issues while importing larger prod sites:
* `mysql server has gone away` with sizeable sql dumps
* `bin/import` exceeding maxBuffer while running cap tasks