### PR TITLE
Datadog integration

### DIFF
--- a/lib/capistrano/tasks/provision.rake
+++ b/lib/capistrano/tasks/provision.rake
@@ -10,6 +10,12 @@ namespace :evolve do
         end
 
         ansible_path = Dir.pwd + "/lib/ansible"
+
+        galaxy_reqs = "#{ansible_path}/galaxy.yml"
+        if File.exists?(galaxy_reqs)
+          system("ansible-galaxy install -r #{galaxy_reqs} --force")
+        end
+
         play = "ansible-playbook -e stage=#{fetch(:stage)}"
 
         success = ansible_execute("#{play} --user=#{fetch(:user)} #{ansible_path}/provision.yml")

--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -289,6 +289,27 @@ var WordpressGenerator = yeoman.generators.Base.extend({
     });
   },
 
+  promptForDatadog: function() {
+    var existing = function() {
+      try {
+        var match = this.readFileAsString(path.join(this.env.cwd, 'lib', 'ansible', 'group_vars', 'all'))
+          .match(/datadog_api_key[ ]*:[ ]*(?:'|")?([^'"\s]+)/i);
+
+        return match[1];
+      } catch(e) {};
+    }.bind(this);
+
+    this.prompts.push({
+      required: true,
+      type:     'text',
+      name:     'datadog',
+      message:  'Datadog license key (leave blank to disable)',
+      default:  function () {
+        return existing() || '';
+      }.bind(this)
+    });
+  },
+
   promptForRoles: function() {
     try {
       var provisionYml = this.readFileAsString(path.join(this.env.cwd, 'lib', 'ansible', 'provision.yml'));

--- a/lib/yeoman/templates/Vagrantfile
+++ b/lib/yeoman/templates/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure("2") do |config|
 
     # Provision local.<%= props.domain %>
     box.vm.provision :ansible do |ansible|
+      ansible.galaxy_role_file = "lib/ansible/galaxy.yml"
       ansible.playbook = "lib/ansible/provision.yml"
       ansible.inventory_path = "lib/ansible/hosts"
       ansible.limit = "local"

--- a/lib/yeoman/templates/_gitignore
+++ b/lib/yeoman/templates/_gitignore
@@ -53,6 +53,7 @@ bower_components
 node_modules
 backups
 web/wp
+lib/ansible/roles
 
 # Generated file, don't edit above this line
 <%= gitignoreFile %>

--- a/lib/yeoman/templates/lib/ansible/galaxy.yml
+++ b/lib/yeoman/templates/lib/ansible/galaxy.yml
@@ -1,0 +1,2 @@
+---
+<% if (props.datadog) { %>- src: Datadog.datadog<% } %>

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -12,6 +12,8 @@ mysql:
   password:     <%= props.DB_PASSWORD %>
   host:         <%= props.DB_HOST %>
 
+<% if (props.datadog) { %>datadog_api_key: '<%= props.datadog %>'<% } %>
+
 # php__memory_limit:
 
 # apache__start_servers:

--- a/lib/yeoman/templates/lib/ansible/provision.yml
+++ b/lib/yeoman/templates/lib/ansible/provision.yml
@@ -17,6 +17,7 @@
     <% if (props.ssl) { %>- pound             # (Optional) SSL support & decryption<% } %><% props.roles.map(function(role) { %>
     <%= role.checked ? '-' : '#' %> <%= role.value %><% }) %>
 <% if (props.newrelic) { %>    - newrelic          # (Optional) New Relic application/server monitoring
+<% } %><% if (props.datadog) { %>    - { role: Datadog.datadog, sudo: yes, when: stage == 'production' } # (Optional) Datadog monitoring support
 <% } %>    # /Optional Features
 
     - cleanup           # (Required) Generate init.d for installed evolution services


### PR DESCRIPTION
This does several things:

* generates a `lib/ansible/galaxy.yml` file for [installing roles from galaxy](http://docs.ansible.com/ansible/galaxy.html#installing-multiple-roles-from-a-file)
* runs `ansible-galaxy` on local and remote provisions, to ensure any needed external roles exist
* adds generator prompt for [Datadog](http://datadoghq.com/) api key
* integrates [Datadog's galaxy role](https://galaxy.ansible.com/detail#/role/4759), which is subsequently run against **production stages only**