### PR TITLE
Provision fails when trying to validate SSL certificate

### DIFF
--- a/lib/ansible/roles/common/tasks/main.yml
+++ b/lib/ansible/roles/common/tasks/main.yml
@@ -9,11 +9,11 @@
   debug:          var=new_hostname
 
 - name:           Fetch kernel purging script
-  get_url:
-    url:          https://raw.githubusercontent.com/EvanK/ubuntu-purge-kernels/master/purge-kernels.py
-    dest:         /tmp/purge-kernels.py
-    mode:         0755
-    force:        yes
+  command:        wget -N -O /tmp/purge-kernels.py https://raw.githubusercontent.com/EvanK/ubuntu-purge-kernels/master/purge-kernels.py
+  sudo:           yes
+
+- name:           Ensure script is executable
+  file:           path=/tmp/purge-kernels.py state=file mode=0755
   sudo:           yes
 
 - name:           Purge kernels as necessary

--- a/lib/ansible/roles/wp-cli/tasks/main.yml
+++ b/lib/ansible/roles/wp-cli/tasks/main.yml
@@ -1,7 +1,7 @@
-- name:       Install wp-cli
-  get_url:
-    url:      https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-    dest:     /usr/local/bin/wp
-    mode:     0755
-    force:    yes
-  sudo:       true
+- name:       Fetch latest wp-cli
+  command:    wget -N -O /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+  sudo:       yes
+
+- name:       Ensure wp-cli is executable
+  file:       path=/usr/local/bin/wp state=file mode=0755
+  sudo:       yes


### PR DESCRIPTION
Provision of vagrant box fails when executing `common` task `Fetch kernel purging script` due to a SSL certificate validation error for `raw.githubusercontent.com:443`.

Vagrant box version: `ubuntu/trusty64 (virtualbox, 20160311.0.0)`

![evolution-wordpress-issue](https://cloud.githubusercontent.com/assets/351530/13811654/74443ec8-eb77-11e5-8fa6-4c937d7cde58.png)
