### PR TITLE
Fixed php config path

### DIFF
--- a/lib/ansible/roles/awstats/tasks/vagrant.yml
+++ b/lib/ansible/roles/awstats/tasks/vagrant.yml
@@ -26,7 +26,7 @@
 
 - name:           Update vhosts for awstats web ui
   replace:        dest=/etc/apache2/sites-available/{{ "%03d" | format(item.key_1) }}-{{ item.value }}.{{ domain }}.conf regexp='^([ \t]+)(LogLevel warn)' replace='\1\2\n\n\1Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch\n\1Alias /awstatsclasses "/usr/share/awstats/lib/"\n\1Alias /awstats-icon "/usr/share/awstats/icon/"\n\1Alias /awstatscss "/usr/share/doc/awstats/examples/css"\n\1ScriptAlias /awstats/ /usr/lib/cgi-bin/'
-  with_nested_dict: apache_vhosts # see ansible/ansible#9563
+  with_nested_dict: "{{ apache_vhosts }}" # see ansible/ansible#9563
   when:           item.key_0 == stage
   notify:         restart apache
   sudo:           true

--- a/lib/ansible/roles/newrelic/tasks/main.yml
+++ b/lib/ansible/roles/newrelic/tasks/main.yml
@@ -15,7 +15,7 @@
     - newrelic-sysmond
 
 - name:           Configure PHP agent license key and app name
-  lineinfile:     dest={{ php_conf.stdout }}/newrelic.ini regexp="^{{ item.key }}" line="{{ item.key }} = '{{ item.value }}'"
+  lineinfile:     dest={{ php_conf_path }}/newrelic.ini regexp="^{{ item.key }}" line="{{ item.key }} = '{{ item.value }}'"
   sudo:           yes
   with_dict:
     newrelic.appname: "{{ domain }} ({{ stage }})"

--- a/lib/ansible/roles/php/tasks/main.yml
+++ b/lib/ansible/roles/php/tasks/main.yml
@@ -4,20 +4,14 @@
   with_items:     "{{ php_packages }}"
   sudo:           yes
 
-- shell:          ls -1d /etc/php5/conf.d 2>/dev/null || ls -1d /etc/php5/mods-available
-  register:       php_conf
-  sudo:           yes
-
-- debug:          var={{ php_conf.stdout }}
-
 - name:           Install PECL packages
-  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php_conf.stdout }}/{{ item if item is string else item.name }}.ini
+  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php_conf_path }}/{{ item if item is string else item.name }}.ini
   with_items:     "{{ pecl_packages }}"
   sudo:           yes
 
 - name:           Enable PECL packages
   lineinfile:     line="extension={{ item if item is string else item.name }}.so"
-                  dest="{{ php_conf.stdout }}/{{ item if item is string else item.name }}.ini"
+                  dest="{{ php_conf_path }}/{{ item if item is string else item.name }}.ini"
                   create=yes
   with_items:     "{{ pecl_packages }}"
   sudo:           yes

--- a/lib/ansible/roles/php/vars/main.yml
+++ b/lib/ansible/roles/php/vars/main.yml
@@ -12,3 +12,5 @@ php_packages:
   - php5-gd
   - php5-mcrypt
   - php5-dev
+
+php_conf_path: '/etc/php5/mods-available'


### PR DESCRIPTION
This addresses a break that was only evident in ansible 2.1+ (still worked fine in 2.0.1.0).

For background, the php role was divining the php configuration path from a shell wildcard back when we needed to support ubuntu precise (for the travis builds). Travis works now with trusty (and the builds are breaking for unrelated reasons anyway)