### PR TITLE
Remove known ssh fingerprints on vagrant provision

### DIFF
--- a/lib/yeoman/templates/Vagrantfile
+++ b/lib/yeoman/templates/Vagrantfile
@@ -1,3 +1,28 @@
+# Borrowed from: http://superuser.com/questions/701735/run-script-on-host-machine-during-vagrant-up#answer-992220
+module LocalCommand
+  class Config < Vagrant.plugin("2", :config)
+    attr_accessor :command
+  end
+
+  class Plugin < Vagrant.plugin("2")
+    name "local_shell"
+
+    config(:local_shell, :provisioner) do
+      Config
+    end
+
+    provisioner(:local_shell) do
+      Provisioner
+    end
+  end
+
+  class Provisioner < Vagrant.plugin("2", :provisioner)
+    def provision
+      result = system "#{config.command}"
+    end
+  end
+end
+
 Vagrant.configure("2") do |config|
   # Configuring the hostmanager to automatically alter the hosts file for development testing
   config.hostmanager.enabled            = true
@@ -41,6 +66,9 @@ Vagrant.configure("2") do |config|
 
     # Remount the default shared folder as NFS for caching and speed
     box.vm.synced_folder ".", "/vagrant", :nfs => true
+
+    # Remove any known hosts when (re)provisioning
+    box.vm.provision "ssh-cleanup", type: "local_shell", command: "(ssh-keygen -R local.<%= props.domain %> && ssh-keygen -R <%= props.ip %>) || :"
 
     # Provision local.<%= props.domain %>
     box.vm.provision :ansible do |ansible|


### PR DESCRIPTION
This should address a FAQ issue that occurrs when repeatedly destroying/recreating a vm:
> https://github.com/evolution/wordpress/blob/master/FAQ.md#capistrano-fails-with-fingerprint-or-host-key-verification-error