### PR TITLE
[RFC] Git submodule support for cap deployments

### DIFF
--- a/lib/yeoman/templates/Capfile
+++ b/lib/yeoman/templates/Capfile
@@ -7,6 +7,9 @@ require 'capistrano/setup'
 # Includes default deployment tasks
 require 'capistrano/deploy'
 
+# Load git submodules as necessary
+require 'capistrano/git-submodule-strategy'
+
 # Includes tasks from other gems included in your Gemfile
 #
 # For documentation on these, see for example:

--- a/lib/yeoman/templates/Gemfile
+++ b/lib/yeoman/templates/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'capistrano', '~> 3.2.1', require: false, group: :development
+gem 'capistrano-git-submodule-strategy', '~> 0.1', require: false, group: :development
 gem 'colored', '~> 1.2', require: false, group: :development
 gem 'launchy', '~> 2.4', require: false, group: :development

--- a/lib/yeoman/templates/Gemfile.lock
+++ b/lib/yeoman/templates/Gemfile.lock
@@ -6,6 +6,8 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
+    capistrano-git-submodule-strategy (0.1.22)
+      capistrano (~> 3.1)
     colored (1.2)
     colorize (0.7.3)
     i18n (0.6.9)
@@ -25,5 +27,6 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano (~> 3.2.1)
+  capistrano-git-submodule-strategy (~> 0.1)
   colored (~> 1.2)
   launchy (~> 2.4)

--- a/lib/yeoman/templates/lib/capistrano/deploy.rb
+++ b/lib/yeoman/templates/lib/capistrano/deploy.rb
@@ -16,6 +16,7 @@ set :deploy_to,     "/var/www/#{fetch(:domain)}/#{fetch(:stage)}/#{fetch(:branch
 set :linked_dirs,   %w{web/wp-content/uploads}
 set :wp_path,       "#{release_path}/web/wp"
 set :www,           <%= props.www ? 'true' : 'false' %>
+set :git_strategy,  Capistrano::Git::SubmoduleStrategy
 
 namespace :deploy do
   after :updated, :bower_install do


### PR DESCRIPTION
This should enable the use of git submodules within a site repository, using [ekho/capistrano-git-submodule-strategy](https://github.com/ekho/capistrano-git-submodule-strategy)