### PR TITLE
Replace capistrano for deployments

### DIFF
--- a/bin/evolve
+++ b/bin/evolve
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import datetime
+import getpass
+import getopt
+import json
+import os
+import os.path
+import pipes
+import socket
+import subprocess
+import sys
+import termcolor
+
+class Evolve:
+    def __init__(self):
+        # separate any command line opts from args
+        try:
+            opts, args = getopt.getopt(sys.argv[1:], '')
+        except getopt.GetoptError as err:
+            pass
+
+        # usage statement when missing args
+        if len(args) < 2:
+            print('Usage: ./bin/evolve <stage> <action> [args...]')
+            sys.exit(1)
+
+        # seperate arguments and expose them for dependency injection
+        self.stage = args.pop(0)
+        self.action = args.pop(0)
+        self.arguments = args
+
+        self.announce('running "%s" task in the "%s" stage' % (self.action, self.stage))
+
+        # determine paths
+        self.working_path = os.getcwd()
+        self.ansible_path = os.path.join(self.working_path, 'lib/ansible')
+        self.tasks_path = os.path.join(os.path.dirname(__file__), '../lib/tasks')
+
+        # install galaxy roles
+        # todo: bypass --force unless roles are older than X?
+        self.call(['ansible-galaxy', 'install', '-r', os.path.join(self.ansible_path, 'galaxy.yml'), '--force'])
+
+        # import and instantiate action
+        sys.path.append(self.tasks_path)
+        try:
+            self.import_action(self.action)
+        except ImportError as err:
+            print(termcolor.colored('Unknown action "%s"' % self.action, 'red'), file=sys.stderr)
+            sys.exit(2)
+        except Exception as err:
+            print(termcolor.colored('The "%s" action failed: %s' % (self.action, err), 'red'), file=sys.stderr)
+            self.log_action(False, ' '.join([self.action] + args))
+        else:
+            self.log_action(True, ' '.join([self.action] + args))
+
+    def announce(self, message):
+        '''
+        Prints a colored announcement across the terminal.
+        '''
+        print(termcolor.colored("\n! %s" % message, 'green'))
+
+    def call(self, *args):
+        '''
+        Prints and runs a command, or piped series of commands, inheriting standard input/output and returning after completion.
+        Throws subprocess.CalledProcessError if returncode was nonzero.
+        '''
+        command = self._normalize_commands(args)
+        print(termcolor.colored("$ %s\n" % command, 'yellow'))
+        return subprocess.check_call(command, shell=True)
+
+    def bg_call(self, *args):
+        '''
+        Runs a command, or piped series of commands, ignoring standard input/output and returning a returncode after completion.
+        '''
+        command = self._normalize_commands(args)
+        # TODO: instead of subprocess.PIPE, should open & provide file descriptors (to temp files?)
+        # TODO: alternatively, use subprocess.Popen with Popen.communicate?
+        return subprocess.call(command, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    def _normalize_commands(self, args):
+        '''
+        Normalizes and escapes one or more commands (as lists), piping each into the command following it.
+        '''
+        groups = []
+
+        for command in args:
+            # remove any None args
+            command = filter(lambda a: a != None, command)
+            # quote each arg for shell metacharacters
+            command = map(pipes.quote, command)
+            # flatten args to string command
+            groups.append(' '.join(command))
+
+        # flatten commands to pipe chain
+        return ' | '.join(groups)
+
+    def single_input(self, prompt, cb):
+        '''
+        Prompts for a single line of input, validating with a given callback.
+        '''
+        built_prompt = "\n? %s: " % prompt
+        while True:
+            result = raw_input(termcolor.colored(built_prompt, 'cyan'))
+
+            try:
+                if cb(result):
+                    return result
+            except:
+                pass
+
+    def multi_input(self, prompt, choices):
+        '''
+        Prompts from a given list of choices.
+        '''
+        built_prompt = termcolor.colored("\n? %s:\n" % prompt, 'cyan')
+
+        for i, choice in enumerate(choices):
+            choices[i] = choice.lower()
+            built_prompt += " %s %s\n" % (
+                termcolor.colored("[%i]" % (i+1), 'grey', 'on_cyan'),
+                termcolor.colored(choice.lower(), 'cyan')
+            )
+
+        built_prompt += termcolor.colored("> ", 'cyan')
+
+        while True:
+            result = raw_input(built_prompt)
+
+            try:
+                test_index = int(result)
+                if 1 <= test_index <= len(choices):
+                    return choices[test_index-1]
+            except (ValueError, IndexError, TypeError):
+                pass
+
+            if result.lower() in choices:
+                return result.lower()
+
+    def password_input(self, prompt):
+        '''
+        Prompts for a password (which is not shown).
+        '''
+        built_prompt = "\n\a? %s: " % prompt
+        return getpass.getpass(termcolor.colored(built_prompt, 'white', 'on_blue'))
+
+    def import_action(self, action):
+        '''
+        Imports an module (expected to be in the tasks path), and instantiates its ActionClass.
+        '''
+        action_module = __import__(action)
+        action_module.ActionClass(self)
+
+    def playbook(self, playbook, extra_vars=None, extra_args=None):
+        '''
+        Runs an ansible playbook, with optional json encoded extra_vars and optional extra arguments.
+        '''
+        call_args = ['ansible-playbook']
+
+        # add extra_vars encoded as json
+        if extra_vars is not None:
+            call_args += ['-e', json.dumps(extra_vars)]
+
+        # add extra args...
+        if extra_args is not None:
+            # append, if a scalar string
+            if isinstance(extra_args, basestring):
+                call_args.append(extra_args)
+            # otherwise add as a list-like
+            else:
+                call_args += extra_args
+
+        # append playbook filepath
+        call_args.append(os.path.join(self.ansible_path, playbook))
+
+        self.call(call_args)
+
+    def log_action(self, success, message):
+        '''
+        Writes a log entry to a remote server, via a specialized ansible playbook.
+        '''
+        local_user = getpass.getuser()
+        local_host = socket.gethostname()
+        local_time = datetime.datetime.today().strftime('%c')
+        status = 'Success' if success else 'Failure'
+
+        extra_vars = {
+            'stage': self.stage,
+            'log_message': '\t'.join([local_time, local_user, message, status])
+        }
+
+        try:
+            self.playbook('log.yml', extra_vars)
+        except subprocess.CalledProcessError as err:
+            print(termcolor.colored('Failed to log action to remote: %s' % err, 'red'), file=sys.stderr)
+
+if __name__ == "__main__":
+    Evolve()

--- a/lib/tasks/provision.py
+++ b/lib/tasks/provision.py
@@ -1,0 +1,23 @@
+import os.path
+import re
+import subprocess
+
+class ActionClass:
+    def __init__(self, evolve):
+        # TODO: implement `invoke "evolve:prepare_key"`
+
+        extra_vars = {
+            'stage': evolve.stage
+        }
+
+        try:
+            evolve.playbook('provision.yml', extra_vars, '--user=deploy')
+        except subprocess.CalledProcessError:
+            evolve.announce('Unable to provision with SSH publickey for deploy user')
+
+            # connect as intermediate user, and set up deploy user
+            username = evolve.single_input('user to provision as (root)', lambda u: not u or re.match(r"^[a-z_][a-z0-9_-]*[$]?", u, re.I)) or 'root'
+            evolve.playbook('user.yml', extra_vars, ['--user=%s' % username, '--ask-pass', '--ask-sudo-pass'])
+
+            # provision as usual
+            evolve.playbook('provision.yml', extra_vars, '--user=deploy')

--- a/lib/yeoman/templates/bin/evolve
+++ b/lib/yeoman/templates/bin/evolve
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+IMPORTER_PATH="$( dirname "$0" )/../bower_components/evolution-wordpress"
+IMPORTER_SCRIPT="$IMPORTER_PATH/bin/evolve"
+
+chmod +x "$IMPORTER_SCRIPT"
+
+$IMPORTER_SCRIPT

--- a/lib/yeoman/templates/lib/ansible/galaxy.yml
+++ b/lib/yeoman/templates/lib/ansible/galaxy.yml
@@ -1,1 +1,3 @@
+- src: carlosbuenosvinos.ansistrano-deploy
+- src: carlosbuenosvinos.ansistrano-rollback
 <% if (props.datadog) { %>- src: Datadog.datadog<% } %>


### PR DESCRIPTION
[Capistrano](http://capistranorb.com/) is a great deployment tool, but it requires a specific sort of ruby runtime environment that can be difficult to set up properly, and the [bundler gem](http://bundler.io/)  whose newer versions have conflicts with vagrant.

In the interest of making evolution easier to both use and maintain, I'd like to replace capistrano and do away with the ruby dependencies entirely.

I'm leaning toward [ansistrano](https://github.com/ansistrano/deploy), which would tie in nicely to our provisioning (that already makes use of ansible).