### PR TITLE
fix file permissions after each sync or deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ test/temp/
 vendor/
 composer.phar
 *.pyc
+
+.vimrc
+

--- a/lib/capistrano/bootstrap.rake
+++ b/lib/capistrano/bootstrap.rake
@@ -36,4 +36,9 @@ namespace :deploy do
   before :started, :release_permissions do
     invoke "evolve:permissions"
   end
+
+  after :finished, :release_permissions do
+    invoke "evolve:permissions"
+  end
 end
+

--- a/lib/capistrano/tasks/files.rake
+++ b/lib/capistrano/tasks/files.rake
@@ -56,7 +56,10 @@ namespace :evolve do
             run_locally do
               execute fetch(:rsync_cmd)
             end
+
           end
+
+          invoke "evolve:permissions"
         else
           warn "!! No local uploads to sync...skipping"
         end

--- a/lib/capistrano/tasks/server.rake
+++ b/lib/capistrano/tasks/server.rake
@@ -81,10 +81,9 @@ namespace :evolve do
         execute :sudo, "find -L #{deploy_to}/releases/*/web -type f -exec chmod 664 {} \\;"
 
         if test :ls, "#{deploy_to}/releases/*/web/wp-content"
-          # Ensure wp-content directories are owned by deploy
-          execute :sudo, "find -L #{deploy_to}/releases/*/web/wp-content -type d -exec chown deploy {} \\;"
           # Ensure upload directory is owned by deploy and writeable by Apache
-          execute :sudo, "find -L #{deploy_to}/shared/web/wp-content/ -type d -exec chown deploy:www-data {} \\; -exec chmod -R 755 {} \\;"
+          execute :sudo, "find -L #{deploy_to}/releases/*/web/wp-content -type d -exec chown deploy:www-data {} \\;"
+          execute :sudo, "find -L #{deploy_to}/releases/*/web/wp-content/uploads/ -type d -exec chmod g+w {} \\;"
         end
       end
     end

--- a/lib/capistrano/tasks/server.rake
+++ b/lib/capistrano/tasks/server.rake
@@ -83,6 +83,8 @@ namespace :evolve do
         if test :ls, "#{deploy_to}/releases/*/web/wp-content"
           # Ensure wp-content directories are owned by deploy
           execute :sudo, "find -L #{deploy_to}/releases/*/web/wp-content -type d -exec chown deploy {} \\;"
+          # Ensure upload directory is owned by deploy and writeable by Apache
+          execute :sudo, "find -L #{deploy_to}/shared/web/wp-content/ -type d -exec chown deploy:www-data {} \\; -exec chmod -R 755 {} \\;"
         end
       end
     end

--- a/lib/capistrano/tasks/up.rake
+++ b/lib/capistrano/tasks/up.rake
@@ -13,6 +13,7 @@ namespace :evolve do
     desc "Uploads local uploads to remote"
     task :files do
       invoke "evolve:files:up"
+      invoke "evolve:permissions"
     end
   end
 end


### PR DESCRIPTION
Various parts of the deployment messed with file permissions that caused problems when uploading files using gravity forms. I this commit simply runs evolve:permissions after deployment or whenever files are synced with evolve:up