### PR TITLE
Ensure a round number for swap size

### DIFF
--- a/lib/ansible/roles/common/templates/swapsize.j2
+++ b/lib/ansible/roles/common/templates/swapsize.j2
@@ -4,16 +4,16 @@
     {%- set _disk_avail_mb = mp.size_available / 1024 / 1024 -%}
     {# if enough space for 2x current memory, use 1x for swap #}
     {%- if _disk_avail_mb >= (ansible_memtotal_mb * 2) -%}
-      {{ ansible_memtotal_mb }}
+      {{ ansible_memtotal_mb | round | int }}
     {# if enough space for 1x current memory, use 1/2 for swap #}
     {%- elif _disk_avail_mb >= ansible_memtotal_mb -%}
-      {{ ansible_memtotal_mb / 2 }}
+      {{ (ansible_memtotal_mb / 2) | round | int }}
     {# if enough space for 1/2 current memory, use 1/4 for swap #}
     {%- elif _disk_avail_mb >= (ansible_memtotal_mb / 2) -%}
-      {{ ansible_memtotal_mb / 4 }}
+      {{ (ansible_memtotal_mb / 4) | round | int }}
     {# if enough space for 1/4 current memory, use 1/8 for swap #}
     {%- elif _disk_avail_mb >= (ansible_memtotal_mb / 4) -%}
-      {{ ansible_memtotal_mb / 8 }}
+      {{ (ansible_memtotal_mb / 8) | round | int }}
     {%- endif -%}
     {# otherwise leave blank, for playbook to handle #}
   {%- endif -%}


### PR DESCRIPTION
Encountered a calculated swap size, as a float. As it happens, `fallocate` does not handle decimal points well:

```
TASK: [common | Calculate ideal swapfile size] ******************************** 
ok: [production.example.com]

TASK: [common | Fetch swapfile size] ****************************************** 
changed: [production.example.com]

TASK: [common | debug var=swapfile_size_mb.stdout] **************************** 
ok: [production.example.com] => {
    "swapfile_size_mb.stdout": "15077.5"
}

TASK: [common | fail msg="Could not determine swapfile size with available diskspace"] *** 
skipping: [production.example.com]

TASK: [common | Write swapfile] *********************************************** 
failed: [production.example.com] => {"changed": true, "cmd": ["fallocate", "-l", "15077.5M", "/swapfile"], "delta": "0:00:00.002901", "end": "2016-09-01 21:53:45.534465", "rc": 1, "start": "2016-09-01 21:53:45.531564"}
stderr: fallocate: invalid length value specified

FATAL: all hosts have already failed -- aborting
```

This rounds and casts to an int (in this example, `15078`)