### PR TITLE
Fix handling of forwarded IP addresses

### DIFF
--- a/lib/ansible/roles/varnish/files/remoteip.conf
+++ b/lib/ansible/roles/varnish/files/remoteip.conf
@@ -1,0 +1,4 @@
+# Declare header field to be parsed for end user IP address
+RemoteIPHeader X-Forwarded-For
+# Declare client IP address trusted to present RemoteIPHeader value
+RemoteIPInternalProxy 127.0.0.1

--- a/lib/ansible/roles/varnish/tasks/main.yml
+++ b/lib/ansible/roles/varnish/tasks/main.yml
@@ -30,8 +30,21 @@
     - restart apache
     - restart varnish
 
-- name:           Enable apache module "rpaf"
-  command:        a2enmod rpaf
+- stat:           path=/etc/apache2/mods-enabled/rpaf.load
+  register:       rpaf_load
+
+- name:           Disable apache module "rpaf" (if installed)
+  command:        a2dismod rpaf
+  when:           rpaf_load.stat.exists
+  sudo:           yes
+  notify:         restart apache
+
+- name:           Configure apache module "remoteip"
+  copy:           src=remoteip.conf dest=/etc/apache2/mods-available/remoteip.conf mode=0644
+  sudo:           yes
+
+- name:           Enable apache module "remoteip"
+  command:        a2enmod remoteip
   sudo:           yes
   notify:         restart apache
 

--- a/lib/ansible/roles/varnish/vars/main.yml
+++ b/lib/ansible/roles/varnish/vars/main.yml
@@ -2,5 +2,4 @@
 role_varnish: true
 
 varnish_packages:
-  - libapache2-mod-rpaf
   - varnish


### PR DESCRIPTION
It seems that the [apache `rpaf` module](https://github.com/y-ken/mod_rpaf) does not work properly under apache 2.4

This will replace it with the [`remoteip` module](http://httpd.apache.org/docs/2.4/mod/mod_remoteip.html), and disable rpaf wherever it is already installed and enabled.

/cc @weeirishman 