### PR TITLE
Optionally bypass xml-rpc blocking...

### DIFF
--- a/lib/ansible/roles/apache/tasks/main.yml
+++ b/lib/ansible/roles/apache/tasks/main.yml
@@ -73,6 +73,14 @@
   ignore_errors:  true
   sudo:           yes
 
+- set_fact:
+    wordpress__xmlrpc_allow: false
+  when: wordpress__xmlrpc_allow is undefined
+
+- set_fact:
+    wordpress__xmlrpc_whitelist: false
+  when: wordpress__xmlrpc_whitelist is undefined
+
 - name:           Disable default apache site
   command:        a2dissite {{ apache_default_vhost.stdout }} removes=/etc/apache2/sites-enabled/{{ apache_default_vhost.stdout }}
   notify:         restart apache

--- a/lib/ansible/roles/apache/templates/virtualhost
+++ b/lib/ansible/roles/apache/templates/virtualhost
@@ -95,24 +95,20 @@
 {% if wordpress__xmlrpc_allow %}
     # Enable XML-RPC unconditionally
     <files xmlrpc.php>
-        Order allow,deny
-        Allow from all
+        Require all granted
     </files>
 {% elif wordpress__xmlrpc_whitelist %}
-    # Enable XML-RPC for the following SetEnvIf conditions
-{% for whitelist_regex, whitelist_varname in wordpress__xmlrpc_whitelist.iteritems() %}
-    SetEnvIf {{ whitelist_varname }} "{{ whitelist_regex }}" allow_wp_xmlrpc
-{% endfor %}
+    # Enable XML-RPC for only the following Require conditions
     <files xmlrpc.php>
-        Order deny,allow
-        Deny from all
-        Allow from env=allow_wp_xmlrpc
+        Require all denied
+{% for whitelist_condition in wordpress__xmlrpc_whitelist %}
+        Require {{ whitelist_condition }}
+{% endfor %}
     </files>
 {% else %}
     # Disable XML-RPC unconditionally
     <files xmlrpc.php>
-        Order allow,deny
-        Deny from all
+        Require all denied
     </files>
 {% endif %}
 

--- a/lib/ansible/roles/apache/templates/virtualhost
+++ b/lib/ansible/roles/apache/templates/virtualhost
@@ -92,12 +92,29 @@
         Deny from all
     </Files>
 {% endif %}
-
-    # Disable XML-RPC
+{% if wordpress__xmlrpc_allow %}
+    # Enable XML-RPC unconditionally
+    <files xmlrpc.php>
+        Order allow,deny
+        Allow from all
+    </files>
+{% elif wordpress__xmlrpc_whitelist %}
+    # Enable XML-RPC for the following SetEnvIf conditions
+{% for whitelist_regex, whitelist_varname in wordpress__xmlrpc_whitelist.iteritems() %}
+    SetEnvIf {{ whitelist_varname }} "{{ whitelist_regex }}" allow_wp_xmlrpc
+{% endfor %}
+    <files xmlrpc.php>
+        Order deny,allow
+        Deny from all
+        Allow from env=allow_wp_xmlrpc
+    </files>
+{% else %}
+    # Disable XML-RPC unconditionally
     <files xmlrpc.php>
         Order allow,deny
         Deny from all
     </files>
+{% endif %}
 
     # Deny access to all .htaccess files
     <Files ~ "^.*\.(?i:hta)">

--- a/lib/ansible/roles/apache/vars/main.yml
+++ b/lib/ansible/roles/apache/vars/main.yml
@@ -13,6 +13,10 @@ apache_modules:
   - setenvif
   - filter
   - mime
+  - authz_core
+  - authz_host
+  - authz_user
+  - authz_groupfile
 
 apache_disabled_modules:
   - autoindex

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -24,7 +24,7 @@ mysql:
 
 # wordpress__xmlrpc_allow: false
 # wordpress__xmlrpc_whitelist:
-#   '^127[.]0[.]0[.]1$': 'Remote_Addr'
+#   - "local"
 
 mail__postmaster: no-reply@<%= props.domain %>
 

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -22,6 +22,10 @@ mysql:
 # apache__max_clients:
 # apache__max_requests_per_child:
 
+# wordpress__xmlrpc_allow: false
+# wordpress__xmlrpc_whitelist:
+#   '^127[.]0[.]0[.]1$': 'Remote_Addr'
+
 mail__postmaster: no-reply@<%= props.domain %>
 
 # iptables__ipv6: 0


### PR DESCRIPTION
Evidently, the Jetpack plugin _requires_ remote access to `xmlrpc.xml` (from wordpress' site), so we need a way around [our default behavior of denying all access to it](https://github.com/evolution/wordpress/blob/0de3498380aaf4cfd79c7588be828ae6f401aa59/lib/ansible/roles/apache/templates/virtualhost#L96-L100) (which we do because it's a gaping security risk).

/cc @ericrasch 