### PR TITLE
Provisioning fails with Ansible 2.1.2.0 

### DIFF
--- a/lib/capistrano/tasks/provision.rake
+++ b/lib/capistrano/tasks/provision.rake
@@ -20,7 +20,7 @@ namespace :evolve do
 
         play = "ansible-playbook -e stage=#{fetch(:stage)}"
 
-        success = ansible_execute("#{play} --user=#{fetch(:user)} #{ansible_path}/provision.yml")
+        success = ansible_execute("#{play} --user=#{fetch(:user)} --private-key=#{ansible_path}/files/ssh/id_rsa #{ansible_path}/provision.yml")
 
         unless success
           error "\n\nUnable to provision with SSH publickey for \"#{fetch(:user)}\" user"
@@ -28,7 +28,7 @@ namespace :evolve do
           set :provision_user, ask('user to provision as', 'root')
 
           ansible_execute("#{play} --user=#{fetch(:provision_user)} --ask-pass --ask-sudo-pass #{ansible_path}/user.yml")
-          ansible_execute("#{play} --user=#{fetch(:user)} #{ansible_path}/provision.yml")
+          ansible_execute("#{play} --user=#{fetch(:user)} --private-key=#{ansible_path}/files/ssh/id_rsa #{ansible_path}/provision.yml")
         end
       end
 

--- a/lib/yeoman/templates/ansible.cfg
+++ b/lib/yeoman/templates/ansible.cfg
@@ -1,7 +1,6 @@
 [defaults]
 
 hostfile          = ./lib/ansible/hosts
-private_key_file  = ./lib/ansible/files/ssh/id_rsa
 remote_user       = deploy
 roles_path        = ./bower_components/evolution-wordpress/lib/ansible/roles
 lookup_plugins    = ./bower_components/evolution-wordpress/lib/ansible/lookup_plugins


### PR DESCRIPTION
Something in [2.1.2.0](https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#212-the-song-remains-the-same---09-29-2016) has broken the way we connect for provisioning:

```
PLAY [production] **************************************************************

TASK [setup] *******************************************************************
fatal: [production.example.com]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh.", "unreachable": true}
    to retry, use: --limit @/Users/someuser/Example.com/lib/ansible/provision.retry

PLAY RECAP *********************************************************************
production.example.com : ok=0    changed=0    unreachable=1    failed=0
```

I've narrowed it down to the way we specify a private key location in the root level `ansible.cfg` of our project, versus specifying it via a command line flag to `ansible-playbook`