### PR TITLE
Option to bypass varnish for the local stage

### DIFF
--- a/lib/yeoman/index.js
+++ b/lib/yeoman/index.js
@@ -311,14 +311,27 @@ var WordpressGenerator = yeoman.generators.Base.extend({
   },
 
   promptForRoles: function() {
+    // populate choices based on static roles array
+    var choices = [];
+    WordpressGenerator.roles.forEach(function (role) {
+      choices.push({
+        name:    WordpressGenerator.padRight(role.name, 14) + ' - ' + role.desc,
+        value:   role.name,
+        checked: role.default,
+      });
+    });
+
     try {
       var provisionYml = this.readFileAsString(path.join(this.env.cwd, 'lib', 'ansible', 'provision.yml'));
 
-      WordpressGenerator.roles.forEach(function (role, index) {
-        var regex = new RegExp('^\\s*-\\s+' + role.value.split(' ')[0], 'm');
+      // detect roles in simple or expanded yaml form
+      // TODO: parse as yaml & evaluate data, instead of brittle string/regex matches
+      choices.forEach(function (role, index) {
+        var simple = new RegExp('^\\s*-\\s+' + role.value, 'm');
+        var expanded = new RegExp('^\\s*-\\s*[{][^}]*?role:\\s*' + role.value, 'm');
 
-        if (!regex.exec(provisionYml)) {
-          WordpressGenerator.roles[index].checked = false;
+        if (!simple.exec(provisionYml) && !expanded.exec(provisionYml)) {
+          choices[index].checked = false;
         }
       });
     } catch(e) {};
@@ -328,7 +341,7 @@ var WordpressGenerator = yeoman.generators.Base.extend({
       type:     'checkbox',
       name:     'roles',
       message:  'Optional features',
-      choices:  WordpressGenerator.roles,
+      choices:  choices,
     });
   },
 
@@ -484,6 +497,54 @@ var WordpressGenerator = yeoman.generators.Base.extend({
     }.bind(this));
   },
 
+  promptForLocalVarnish: function() {
+    // test whether varnish role is used in the first place
+    var doVarnish = this.props.roles.filter(function (value) {
+      return value == 'varnish';
+    });
+
+    // prompt for local varnish bypass, as necessary
+    if (doVarnish.length) {
+      var choices = [
+        {
+          name:   'Yes, enable varnish locally',
+          value:  true,
+        },
+        {
+          name:   'No, just on staging and production',
+          value:  false,
+        },
+      ];
+
+      try {
+        var provisionYml = this.readFileAsString(path.join(this.env.cwd, 'lib', 'ansible', 'provision.yml'));
+
+        if (provisionYml.indexOf("{ role: varnish, when: stage != 'local' }") != -1) {
+          choices.reverse();
+        }
+      } catch(e) {};
+
+      var done = this.async();
+
+      this.prompt(
+        [
+          {
+            required: true,
+            type:     'list',
+            name:     'varnishLocal',
+            message:  'Enable varnish on your local stage?',
+            choices:  choices,
+          }
+        ], function(props) {
+        this.props.varnishLocal = props.varnishLocal;
+
+        done();
+      }.bind(this));
+    } else {
+      this.props.varnishLocal = true;
+    }
+  },
+
   prepareReadme: function() {
     try {
       this.readmeFile = this.readFileAsString(path.join(this.env.cwd, 'README.md'));
@@ -519,7 +580,17 @@ var WordpressGenerator = yeoman.generators.Base.extend({
 
   prepareRoles: function() {
     this.props.roles = WordpressGenerator.roles.map(function(role) {
-      role.checked = !!~this.props.roles.indexOf(role.value);
+      var checked = !!~this.props.roles.indexOf(role.name);
+
+      role.value = (checked ? '-' : '#') + ' ';
+
+      if (role.name == 'varnish' && !this.props.varnishLocal) {
+        role.value += "{ role: varnish, when: stage != 'local' }";
+      } else {
+        role.value += WordpressGenerator.padRight(role.name, 17);
+      }
+
+      role.value += ' # (Optional) ' + role.desc;
 
       return role;
     }.bind(this));
@@ -727,41 +798,49 @@ var WordpressGenerator = yeoman.generators.Base.extend({
 
 WordpressGenerator.roles = [
   {
-    name:     'apache-prefork - Dynamic Apache performance tuning',
-    value:    'apache-prefork    # (Optional) Dynamic Apache performance tuning',
-    checked:  true,
+    name:     'apache-prefork',
+    desc:     'Dynamic Apache performance tuning',
+    default:  true,
   },
   {
-    name:     'php-hardened   - Security-minded restrictions on PHP userland',
-    value:    'php-hardened      # (Optional) Security-minded restrictions on PHP userland',
-    checked:  true,
+    name:     'php-hardened',
+    desc:     'Security-minded restrictions on PHP userland',
+    default:  true,
   },
   {
-    name:     'varnish        - High-performance reverse-proxy cache',
-    value:    'varnish           # (Optional) High-performance reverse-proxy cache',
-    checked:  true,
+    name:     'varnish',
+    desc:     'High-performance reverse-proxy cache',
+    default:  true,
   },
   {
-    name:     'mail           - Ability to send e-mails from the server (i.e. PHP)',
-    value:    'mail              # (Optional) Ability to send e-mails from the server (i.e. PHP)',
-    checked:  true,
+    name:     'mail',
+    desc:     'Ability to send e-mails from the server (i.e. PHP)',
+    default:  true,
   },
   {
-    name:     'firewall       - Simple intrusion protection via Fail2ban + iptables',
-    value:    'firewall          # (Optional) Simple intrusion protection via Fail2ban + iptables',
-    checked:  true,
+    name:     'firewall',
+    desc:     'Simple intrusion protection via Fail2ban + iptables',
+    default:  true,
   },
   {
-    name:     'debug          - Tools to monitor processes & debug when on the server',
-    value:    'debug             # (Optional) Tools to monitor processes & debug when on the server',
-    checked:  true,
+    name:     'debug',
+    desc:     'Tools to monitor processes & debug when on the server',
+    default:  true,
   },
   {
-    name:     'awstats        - HTTP log analyzer',
-    value:    'awstats           # (Optional) HTTP log analyzer',
-    checked:  true,
+    name:     'awstats',
+    desc:     'HTTP log analyzer',
+    default:  true,
   },
 ];
+
+WordpressGenerator.padRight = function(str, len, char) {
+  if (str.length < len) {
+    return str + Array(len - str.length + 1).join(char||" ");
+  } else {
+    return str;
+  }
+};
 
 WordpressGenerator.latest = function(username, repo, fn) {
   request({

--- a/lib/yeoman/templates/lib/ansible/provision.yml
+++ b/lib/yeoman/templates/lib/ansible/provision.yml
@@ -14,8 +14,8 @@
     - wp-cli            # (Required) CLI for managing WordPress
 
     # Optional Features
-    <% if (props.ssl) { %>- pound             # (Optional) SSL support & decryption<% } %><% props.roles.map(function(role) { %>
-    <%= role.checked ? '-' : '#' %> <%= role.value %><% }) %>
+    <% if (props.ssl) { %>- pound             # (Optional) SSL support & decryption<% } %><% props.roles.forEach(function(role) { %>
+    <%= role.value %><% }) %>
 <% if (props.newrelic) { %>    - { role: newrelic, sudo: yes, when: stage == 'production' }        # (Optional) New Relic application/server monitoring
 <% } %><% if (props.datadog) { %>    - { role: Datadog.datadog, sudo: yes, when: stage == 'production' } # (Optional) Datadog monitoring support
 <% } %>    # /Optional Features


### PR DESCRIPTION
The prompt for optional roles to enable/disable remains the same (at least as far as the user sees):
![roles-prompt](https://cloud.githubusercontent.com/assets/84145/19502681/7b063a54-9563-11e6-9d7c-a60263dde06f.png)

But when the `varnish` role is enabled, we show an additional prompt:
![varnish-local-prompt](https://cloud.githubusercontent.com/assets/84145/19502864/75ee003c-9564-11e6-99ca-f44df61a76a9.jpg)

We then write it to the provisioning playbook differently, depending on the result:

![varnish-all](https://cloud.githubusercontent.com/assets/84145/19502799/13405dea-9564-11e6-9d05-2c541296a391.png)
vs
![varnish-local](https://cloud.githubusercontent.com/assets/84145/19502819/2aaeded4-9564-11e6-9a10-5896e91cacf7.png)

Fixes #141