### PR TITLE
bump MySQL version to 5.6

### DIFF
--- a/lib/ansible/roles/mysql/vars/main.yml
+++ b/lib/ansible/roles/mysql/vars/main.yml
@@ -3,6 +3,6 @@ role_mysql: true
 
 mysql_packages:
   - libapache2-mod-auth-mysql
-  - mysql-server
+  - mysql-server-5.6
   - php5-mysql
   - python-mysqldb


### PR DESCRIPTION
Fix MySQL issue with utf8mb4_unicode_520_ci collation by upgrading to version of MySQL(5.5->5.6) that supports this collation. 

Issue https://github.com/evolution/wordpress/issues/163