### PR TITLE
need another dependency for mysql-server-core-5.6

### DIFF
--- a/lib/ansible/roles/mysql/vars/main.yml
+++ b/lib/ansible/roles/mysql/vars/main.yml
@@ -4,5 +4,6 @@ role_mysql: true
 mysql_packages:
   - libapache2-mod-auth-mysql
   - mysql-server-5.6
+  - mysql-server-core-5.6
   - php5-mysql
   - python-mysqldb


### PR DESCRIPTION
Apparently they've separated out the packages? 
Came across this regenerating a site.

Thanks Evan!
