### PR TITLE
Optional PHP 7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ npm install -g bower yo generator-evolve
 * [Upgrading from an existing Genesis site](./docs/UPGRADE-FAQ.md)
 * [Importing a non Evolution site](./docs/TUTORIAL-IMPORT.md)
 * [Caveats for developing themes and plugins](./docs/REF-caveats-constants.md)
+* [Common variable overrides](./docs/REF-groupvar-overrides.md)
 
 ## Managing Remote Environments
 

--- a/docs/REF-groupvar-overrides.md
+++ b/docs/REF-groupvar-overrides.md
@@ -1,0 +1,122 @@
+# Group_var overrides
+
+This documents variables that can be overridden in your site's ansible group vars file (located in `lib/ansible/group_vars/all`) to change various evolution behaviors.
+
+* [PHP](#php)
+  * [`php__memory_limit`](#php__memory_limit)
+  * [`php__version_7`](#php__version_7)
+* [Apache](#apache)
+  * [`apache__start_servers`](#apache__start_servers)
+  * [`apache__min_spare_servers`](#apache__min_spare_servers)
+  * [`apache__max_spare_servers`](#apache__max_spare_servers)
+  * [`apache__max_clients`](#apache__max_clients)
+  * [`apache__max_requests_per_child`](#apache__max_requests_per_child)
+* [Wordpress](#wordpress)
+  * [`wordpress__xmlrpc_allow`](#wordpress__xmlrpc_allow)
+  * [`wordpress__xmlrpc_whitelist`](#wordpress__xmlrpc_whitelist)
+* [IPTables](#iptables)
+  * [`iptables__ipv6`](#iptables__ipv6)
+* [Fail2ban](#fail2ban)
+  * [`fail2ban__whitelist`](#)
+  * [`fail2ban__ban_time`](#)
+  * [`fail2ban__notification_email`](#)
+  * [`fail2ban__notify_on_ban`](#)
+* [Swapfile](#swapfile)
+  * [`swap__path`](#swap__path)
+  * [`swap__swappiness`](#swap__swappiness)
+  * [`swap__vfs_cache_pressure`](#swap__vfs_cache_pressure)
+
+---
+
+## PHP
+
+### `php__memory_limit`
+
+Sets PHP's [memory_limit](http://php.net/manual/en/ini.core.php#ini.memory-limit) directive (in megabytes):
+
+```yml
+# Configure PHP with 4 gigabytes of memory
+php__memory_limit: 4096
+```
+
+By default, this is [calculated during provisioning based on the server's total available memory](https://github.com/evolution/wordpress/blob/0de3498380aaf4cfd79c7588be828ae6f401aa59/lib/ansible/roles/php/tasks/main.yml#L19-L23).
+
+### `php__version_7`
+
+Triggers installation and use of PHP 7.1 from [a custom PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php):
+
+```yml
+# Install PHP 7.1
+php__version_7: true
+```
+
+By default, Ubuntu's provided packages for 5.5 are used.
+
+## Apache
+
+Several overrides are available for the [MPM prefork module](https://httpd.apache.org/docs/2.4/mod/prefork.html) that Apache uses with PHP.  By default, these prefork directives are [calculated during provisioning based on the server's available resources](https://github.com/evolution/wordpress/blob/0de3498380aaf4cfd79c7588be828ae6f401aa59/lib/ansible/roles/apache-prefork/templates/prefork.conf)
+
+### `apache__start_servers`
+
+The number of child server processes created by Apache on startup.
+
+### `apache__min_spare_servers`
+
+The minimum number of idle child server processes.
+
+### `apache__max_spare_servers`
+
+The maximum number of idle child server processes.
+
+### `apache__max_clients`
+
+The limit on the number of simultaneous requests that will be served.
+
+### `apache__max_requests_per_child`
+
+The limit on the number of connections that an individual child server process will handle.
+
+## Wordpress
+
+By default, access to Wordpress' XML-RPC functionality is unconditionally denied due to security concerns. There are two methods for overriding this, outlined below.
+
+### `wordpress__xmlrpc_allow`
+
+A truthy value for this override allows unconditional access to Wordpress' XML-RPC:
+
+```yml
+wordpress__xmlrpc_allow: true
+```
+
+This would generate the following in your virtual host configuration:
+
+```apache
+    # Enable XML-RPC unconditionally
+    <files xmlrpc.php>
+        Order allow,deny
+        Allow from all
+    </files>
+```
+
+### `wordpress__xmlrpc_whitelist`
+
+A dictionary (key-value hash) for this override allows conditional access by way of [Apache's SetEnvIf](https://httpd.apache.org/docs/2.4/mod/mod_setenvif.html#setenvif) directive.
+
+The key is a regular expression match (that must be unique within the whitelist), and the value is an attribute that the expression would successfully match. This, for example, would allow XML-RPC requests from the local host:
+
+```yml
+wordpress__xmlrpc_whitelist:
+  '^127[.]0[.]0[.]1$': 'Remote_Addr'
+```
+
+This would generate the following in your virtual host configuration:
+
+```apache
+    # Enable XML-RPC for the following SetEnvIf conditions
+    SetEnvIf Remote_Addr "^127[.]0[.]0[.]1$" allow_wp_xmlrpc
+    <files xmlrpc.php>
+        Order deny,allow
+        Deny from all
+        Allow from env=allow_wp_xmlrpc
+    </files>
+```

--- a/lib/ansible/roles/newrelic/tasks/main.yml
+++ b/lib/ansible/roles/newrelic/tasks/main.yml
@@ -15,7 +15,7 @@
     - newrelic-sysmond
 
 - name:           Configure PHP agent license key and app name
-  lineinfile:     dest={{ php_conf_path }}/newrelic.ini regexp="^{{ item.key }}" line="{{ item.key }} = '{{ item.value }}'"
+  lineinfile:     dest={{ php_mods_path }}/newrelic.ini regexp="^{{ item.key }}" line="{{ item.key }} = '{{ item.value }}'"
   sudo:           yes
   with_dict:
     newrelic.appname: "{{ domain }} ({{ stage }})"

--- a/lib/ansible/roles/php-hardened/tasks/main.yml
+++ b/lib/ansible/roles/php-hardened/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 - name:           Disable allow_url_fopen
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*allow_url_fopen' line='allow_url_fopen = Off'
+  lineinfile:     dest={{ php_conf_path }}/apache2/php.ini backup=yes regexp='^[;# ]*allow_url_fopen' line='allow_url_fopen = Off'
+  when:           php__version_7 == false
   sudo:           yes
 
 - include:        suhosin.yml
+  when:           php__version_7 == false
+
+# NOTE: Suhosin is pre-alpha for php7, so we'll just have to do without it for now
+# see: https://github.com/sektioneins/suhosin7

--- a/lib/ansible/roles/php-hardened/vars/main.yml
+++ b/lib/ansible/roles/php-hardened/vars/main.yml
@@ -6,6 +6,6 @@ php_disable_functions:
   - passthru
 
 suhosin:
-  ini: /etc/php5/mods-available/suhosin.ini
+  ini: "{{ php_mods_path }}/suhosin.ini"
   url: https://download.suhosin.org/suhosin-0.9.38.tar.gz
   sha: 20af6379c0ff9879c5ed69452a6c38b7b3e76748

--- a/lib/ansible/roles/php/tasks/main.yml
+++ b/lib/ansible/roles/php/tasks/main.yml
@@ -1,35 +1,44 @@
 ---
-- name:           Install PHP packages
-  apt:            pkg={{ item }}
-  with_items:     "{{ php_packages }}"
-  sudo:           yes
+# default to php5 when this var is not set
+- set_fact:
+    php__version_7: false
+  when: php__version_7 is undefined
 
-- name:           Install PECL packages
-  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php_conf_path }}/{{ item if item is string else item.name }}.ini
-  with_items:     "{{ pecl_packages }}"
-  sudo:           yes
+- debug: var=php__version_7
 
-- name:           Enable PECL packages
-  lineinfile:     line="extension={{ item if item is string else item.name }}.so"
-                  dest="{{ php_conf_path }}/{{ item if item is string else item.name }}.ini"
-                  create=yes
-  with_items:     "{{ pecl_packages }}"
-  sudo:           yes
+- name: Register installed PHP major version
+  shell: "php --version | grep -i cli | perl -pe 's|^PHP ([0-9]+)[.].*$|$1|i'"
+  ignore_errors: true
+  register: php_major_version
 
-- name:           Calculate PHP memory_limit
-  command:        echo "{{ 256 if ansible_memtotal_mb > 2048 else 128 }}"
-  register:       calc_php_memory_limit
-  ignore_errors:  true
-  when:           php__memory_limit is undefined
+- debug: msg={{ php_major_version }}
 
-- name:           Update php.ini's date.timezone
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*date\.timezone' line='date.timezone = "America/Chicago"'
-  sudo:           yes
+# remove php7 as necessary before we install php5
+- include: php7-uninstall.yml
+  when: php_major_version.stdout == "7" and php__version_7 == false
+  sudo: yes
 
-- name:           Update php.ini's memory_limit
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php__memory_limit }}M'
-  sudo:           yes
+# remove php5 as necessary before we install php7
+- include: php5-uninstall.yml
+  when: php_major_version.stdout == "5" and php__version_7 == true
+  sudo: yes
 
-- name:           Update php.ini's upload_max_filesize
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='^[;# ]*upload_max_filesize' line='upload_max_filesize = 16M'
-  sudo:           yes
+- include: php5-install.yml
+  when: php__version_7 == false
+  sudo: yes
+
+- include: php7-install.yml
+  when: php__version_7 == true
+  sudo: yes
+
+- name: Register php_conf_path for subsequent roles
+  set_fact:
+    php_conf_path: "{{ php7_conf_path if php__version_7 == true else php5_conf_path }}"
+
+- debug: var=php_conf_path
+
+- name: Register php_mods_path for subsequent roles
+  set_fact:
+    php_mods_path: "{{ php7_mods_path if php__version_7 == true else php5_mods_path }}"
+
+- debug: var=php_mods_path

--- a/lib/ansible/roles/php/tasks/php5-install.yml
+++ b/lib/ansible/roles/php/tasks/php5-install.yml
@@ -1,0 +1,35 @@
+---
+- name:           Install PHP packages
+  apt:            pkg={{ item }}
+  with_items:     "{{ php5_packages }}"
+  sudo:           yes
+
+- name:           Install PECL packages
+  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php5_mods_path }}/{{ item if item is string else item.name }}.ini
+  with_items:     "{{ pecl5_packages }}"
+  sudo:           yes
+
+- name:           Enable PECL packages
+  lineinfile:     line="extension={{ item if item is string else item.name }}.so"
+                  dest="{{ php5_mods_path }}/{{ item if item is string else item.name }}.ini"
+                  create=yes
+  with_items:     "{{ pecl5_packages }}"
+  sudo:           yes
+
+- name:           Calculate PHP memory_limit
+  command:        echo "{{ 256 if ansible_memtotal_mb > 2048 else 128 }}"
+  register:       calc_php_memory_limit
+  ignore_errors:  true
+  when:           php__memory_limit is undefined
+
+- name:           Update php.ini's date.timezone
+  lineinfile:     dest={{ php5_conf_path }}/apache2/php.ini backup=yes regexp='^[;# ]*date\.timezone' line='date.timezone = "America/Chicago"'
+  sudo:           yes
+
+- name:           Update php.ini's memory_limit
+  lineinfile:     dest={{ php5_conf_path }}/apache2/php.ini backup=yes regexp='^[;# ]*memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php__memory_limit }}M'
+  sudo:           yes
+
+- name:           Update php.ini's upload_max_filesize
+  lineinfile:     dest={{ php5_conf_path }}/apache2/php.ini backup=yes regexp='^[;# ]*upload_max_filesize' line='upload_max_filesize = 16M'
+  sudo:           yes

--- a/lib/ansible/roles/php/tasks/php5-uninstall.yml
+++ b/lib/ansible/roles/php/tasks/php5-uninstall.yml
@@ -1,0 +1,15 @@
+---
+- name:           Uninstall PECL packages
+  command:        pecl uninstall {{ item if item is string else item.name + '-' + item.version }} removes={{ php5_mods_path }}/{{ item if item is string else item.name }}.ini
+  with_items:     "{{ pecl5_packages }}"
+  sudo:           yes
+
+- name:           Remove PECL ini files as necessary
+  file:           state=absent path="{{ php5_mods_path }}/{{ item if item is string else item.name }}.ini"
+  with_items:     "{{ pecl5_packages }}"
+  sudo:           yes
+
+- name:           Uninstall PHP packages
+  apt:            state=absent pkg={{ item }}
+  with_items:     "{{ php5_packages }}"
+  sudo:           yes

--- a/lib/ansible/roles/php/tasks/php7-install.yml
+++ b/lib/ansible/roles/php/tasks/php7-install.yml
@@ -1,0 +1,39 @@
+---
+- name:           Install PHP7 ppa
+  apt_repository: repo="ppa:ondrej/php" update_cache=yes
+  sudo:           yes
+
+- name:           Install PHP packages
+  apt:            pkg={{ item }}
+  with_items:     "{{ php7_packages }}"
+  sudo:           yes
+
+- name:           Install PECL packages
+  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php7_mods_path }}/{{ item if item is string else item.name }}.ini
+  with_items:     "{{ pecl7_packages }}"
+  sudo:           yes
+
+- name:           Enable PECL packages
+  lineinfile:     line="extension={{ item if item is string else item.name }}.so"
+                  dest="{{ php7_mods_path }}/{{ item if item is string else item.name }}.ini"
+                  create=yes
+  with_items:     "{{ pecl7_packages }}"
+  sudo:           yes
+
+- name:           Calculate PHP memory_limit
+  command:        echo "{{ 256 if ansible_memtotal_mb > 2048 else 128 }}"
+  register:       calc_php_memory_limit
+  ignore_errors:  true
+  when:           php__memory_limit is undefined
+
+- name:           Update php.ini's date.timezone
+  lineinfile:     dest={{ php7_conf_path }}/apache2/php.ini backup=yes regexp='^[;# ]*date\.timezone' line='date.timezone = "America/Chicago"'
+  sudo:           yes
+
+- name:           Update php.ini's memory_limit
+  lineinfile:     dest={{ php7_conf_path }}/apache2/php.ini backup=yes regexp='^[;# ]*memory_limit' line='memory_limit = {{ calc_php_memory_limit.stdout if calc_php_memory_limit.stdout is defined else php__memory_limit }}M'
+  sudo:           yes
+
+- name:           Update php.ini's upload_max_filesize
+  lineinfile:     dest={{ php7_conf_path }}/apache2/php.ini backup=yes regexp='^[;# ]*upload_max_filesize' line='upload_max_filesize = 16M'
+  sudo:           yes

--- a/lib/ansible/roles/php/tasks/php7-uninstall.yml
+++ b/lib/ansible/roles/php/tasks/php7-uninstall.yml
@@ -1,0 +1,19 @@
+---
+- name:           Uninstall PECL packages
+  command:        pecl uninstall {{ item if item is string else item.name + '-' + item.version }} removes={{ php7_mods_path }}/{{ item if item is string else item.name }}.ini
+  with_items:     "{{ pecl7_packages }}"
+  sudo:           yes
+
+- name:           Remove PECL ini files as necessary
+  file:           state=absent path="{{ php7_mods_path }}/{{ item if item is string else item.name }}.ini"
+  with_items:     "{{ pecl7_packages }}"
+  sudo:           yes
+
+- name:           Uninstall PHP packages
+  apt:            state=absent pkg={{ item }}
+  with_items:     "{{ php7_packages }}"
+  sudo:           yes
+
+- name:           Remove PHP7 ppa
+  apt_repository: repo="ppa:ondrej/php" state=absent update_cache=yes
+  sudo:           yes

--- a/lib/ansible/roles/php/vars/main.yml
+++ b/lib/ansible/roles/php/vars/main.yml
@@ -1,8 +1,10 @@
 ---
-pecl_packages:
+pecl5_packages:
   - { name: 'scream', version: '0.1.0'}
 
-php_packages:
+pecl7_packages: []
+
+php5_packages:
   - libapache2-mod-php5
   - php-pear
   - php5
@@ -13,4 +15,19 @@ php_packages:
   - php5-mcrypt
   - php5-dev
 
-php_conf_path: '/etc/php5/mods-available'
+php7_packages:
+  - libapache2-mod-php7.1
+  - php-pear
+  - php7.1
+  - php7.1-cli
+  - php7.1-common
+  - php7.1-curl
+  - php7.1-gd
+  - php7.1-mcrypt
+  - php7.1-dev
+
+php5_conf_path: '/etc/php5'
+php7_conf_path: '/etc/php/7.1'
+
+php5_mods_path: '{{ php5_conf_path }}/mods-available'
+php7_mods_path: '{{ php7_conf_path }}/mods-available'

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -15,6 +15,7 @@ mysql:
 <% if (props.datadog) { %>datadog_api_key: '<%= props.datadog %>'<% } %>
 
 # php__memory_limit:
+# php__version_7: false
 
 # apache__start_servers:
 # apache__min_spare_servers:


### PR DESCRIPTION
Added a group var `php__version_7`, disabled by default, that will _remove an existing php5 installation_ (if any) before adding a custom ppa and installing php7 in its place.

> Note: PHP 7 does not support the `scream` pecl extension (normally installed on the local stage), and **[Suhosin](https://github.com/sektioneins/suhosin7) support is still in pre-alpha** and so is not stable for production use

Props to @weeirishman for doing most of the leg work here!