### PR TITLE
Snapshot-related updates + cap tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Evolution lets you generate an entirely versioned, multi-environment Wordpress s
 * [Vagrant](https://www.vagrantup.com/) server for local development
 * Automated [Ansible](http://www.ansible.com/) provisioning
 * Automated [Capistrano](http://capistranorb.com/) deployment
+* Interval and on-demand backups to the cloud provider of your choice, and on-demand restore
 * Passwordless login over SSH
 * Secure HTTPS encryption
 * Server-side [Varnish](https://www.varnish-cache.org/) caching

--- a/docs/REF-cap-tasks.md
+++ b/docs/REF-cap-tasks.md
@@ -3,6 +3,8 @@
 * [deploy](#deploy)
 * [wp:{command}[:subcommand[..]]](#wpcommandsubcommand)
 * [evolve:update](#evolveupdate)
+* [evolve:snapshot:simulate](#evolvesnapshotsimulate)
+* [evolve:snapshot:restore](#evolvesnapshotrestore)
 * [evolve:provision](#evolveprovision)
 * [evolve:ssh](#evolvessh)
 * [evolve:version](#evolveversion)
@@ -54,6 +56,46 @@ bundle exec cap staging evolve:update[major,themes]
 ```
 
 Note that **committing updates back to git requires a deploy key with write permissions**.
+
+### evolve:snapshot:simulate
+
+Invokes server-side [backup script](https://github.com/evolution/wordpress/blob/master/lib/ansible/roles/snapshots/files/backup.py) to simulate snapshot history for the past year, given an interactive choice of relevant configuration values:
+
+```
+bundle exec cap production evolve:snapshot:simulate
+? By what interval of time should we take snapshots? days
+? And we'll take a snapshot every how many days? 1
+? Retain how many hourly backups? 0
+? Retain how many daily backups? 1
+? Retain how many weekly backups? 1
+? Retain how many monthly backups? 1
+? Retain how many yearly backups? 1
+? Should backup retention lag one day behind? Yes
+
+! Simulating a backup every 1 days
+! Retention policy:
+! 	1 days
+! 	1 weeks
+! 	1 months
+! 	1 years
+! created on                  deleted on                  retained for       filename
+--------------------------  --------------------------  -----------------  -----------------------------------------------------
+2016-07-12 16:59:42.912563  2017-01-02 16:59:42.912563  174 days, 0:00:00  production.example.com-2016-07-12_16-59-42.912563.tgz
+```
+
+This is useful for estimating storage requirements, as you fine-tune your snapshotting configuration.
+
+### evolve:snapshot:restore
+
+Invokes aforementioned backup script, allowing you to select one from a list of existing production snapshots, and seamlessly restore it to your local or production stage:
+
+```
+bundle exec cap production evolve:snapshot:restore
+? Select which backup to restore production.example.com-2017-07-12_15-43-23.292826.tgz
+? To where should we restore this backup? production
+```
+
+Note that **this is destructive to the targeted stage**, and _will wipe out any existing database content or uploaded files_.
 
 ### evolve:provision
 

--- a/docs/REF-cap-tasks.md
+++ b/docs/REF-cap-tasks.md
@@ -4,6 +4,7 @@
 * [wp:{command}[:subcommand[..]]](#wpcommandsubcommand)
 * [evolve:update](#evolveupdate)
 * [evolve:snapshot:simulate](#evolvesnapshotsimulate)
+* [evolve:snapshot:force](#evolvesnapshotforce)
 * [evolve:snapshot:restore](#evolvesnapshotrestore)
 * [evolve:provision](#evolveprovision)
 * [evolve:ssh](#evolvessh)
@@ -84,6 +85,16 @@ bundle exec cap production evolve:snapshot:simulate
 ```
 
 This is useful for estimating storage requirements, as you fine-tune your snapshotting configuration.
+
+### evolve:snapshot:force
+
+Invokes said backup script, forcing a backup to be created outside of the snapshot interval, and skipping retention processing.
+
+```
+bundle exec cap production evolve:snapshot:force
+! Forcing backup...
+Created backup 2017-07-15_18-53-51.021091
+```
 
 ### evolve:snapshot:restore
 

--- a/docs/REF-snapshots-config.md
+++ b/docs/REF-snapshots-config.md
@@ -9,6 +9,8 @@
 
 ---
 
+> See also the snapshot-specific [cap tasks](./REF-cap-tasks.md).
+
 ### Local vs Cloud Storage
 
 Keeping backups on the local filesystem, while simpler to configure, does not make for a good disaster recovery scenario. To this end, Evolution now supports snapshots to a variety of cloud storage providers via [Apache Libcloud](https://libcloud.readthedocs.io/en/latest/).

--- a/lib/ansible/roles/snapshots/files/backup.py
+++ b/lib/ansible/roles/snapshots/files/backup.py
@@ -163,7 +163,7 @@ class BackupManager:
                 if os.path.exists(backup_path):
                     working_dir = mkdtemp(prefix='evolution_restore')
                     backup_dest = '%s/%s' % (working_dir, self.arguments.retrieve)
-                    shutil.move(backup_path, backup_dest)
+                    shutil.copy(backup_path, backup_dest)
                     print(backup_dest)
                 else:
                     raise RuntimeError('Failed to find backup %s' % backup_path)
@@ -232,7 +232,7 @@ class BackupManager:
 
         # dump database to sql file
         verbosity = '--verbose' if self.arguments.verbose > 1 else None
-        self.call(['mysqldump', '--opt', verbosity, '--user=root', '--databases', '%s_%s' % (self.config['dbname'], self.config['stage']), '--result-file', '%s/tarball/db.sql' % working_dir])
+        self.call(['mysqldump', '--opt', verbosity, '--user=root', '--result-file', '%s/tarball/db.sql' % working_dir, '%s_%s' % (self.config['dbname'], self.config['stage'])])
 
         # rsync uploads to subdir
         uploads_src = '%s/current/web/wp-content/uploads' % self.config['releasepath']

--- a/lib/ansible/roles/snapshots/files/backup.py
+++ b/lib/ansible/roles/snapshots/files/backup.py
@@ -12,12 +12,17 @@ from tabulate import tabulate
 from tempfile import mkdtemp
 
 import json
+import libcloud.security
+import libcloud.utils
 import os
 import pipes
 import re
 import shutil
 import subprocess
 import sys
+
+libcloud.utils.SHOW_IN_DEVELOPMENT_WARNING = False
+libcloud.security.VERIFY_SSL_CERT = True
 
 class BackupManager:
     # static properties
@@ -113,8 +118,10 @@ class BackupManager:
 
                 if container_exists == False:
                     self.container = self.driver.create_container(container_name)
+                    self.announce_verbose('Created container: %s' % container_name)
                 else:
                     self.container = self.driver.get_container(container_name)
+                    self.announce_verbose('Found existing container: %s' % container_name)
             else:
                 if not os.path.exists(self.config['container']):
                     os.makedirs(self.config['container'], self.backup_mode)

--- a/lib/ansible/roles/snapshots/files/backup.py
+++ b/lib/ansible/roles/snapshots/files/backup.py
@@ -247,6 +247,8 @@ class BackupManager:
         for key in retention.keys():
             if retention[key] is None:
                 retention[key] = 0
+            else:
+                retention[key] = int(retention[key])
 
         return retention
 

--- a/lib/ansible/roles/snapshots/files/backup.py
+++ b/lib/ansible/roles/snapshots/files/backup.py
@@ -152,16 +152,19 @@ class BackupManager:
             if self.config['method'].lower() != 'local':
                 backup_object = self.driver.get_object(self.container.name, self.arguments.retrieve)
                 working_dir = mkdtemp(prefix='evolution_restore')
-                download_success = self.driver.download_object(backup_object, working_dir)
+                backup_dest = '%s/%s' % (working_dir, backup_object.name)
+                download_success = self.driver.download_object(backup_object, backup_dest)
                 if download_success:
-                    print(working_dir, backup_object.name)
+                    print(backup_dest)
                 else:
                     raise RuntimeError('Failed to download object %s' % backup_object.name)
             else:
                 backup_path = '%s/%s' % (self.config['container'], self.arguments.retrieve)
                 if os.path.exists(backup_path):
                     working_dir = mkdtemp(prefix='evolution_restore')
-                    shutil.move(backup_path, working_dir)
+                    backup_dest = '%s/%s' % (working_dir, self.arguments.retrieve)
+                    shutil.move(backup_path, backup_dest)
+                    print(backup_dest)
                 else:
                     raise RuntimeError('Failed to find backup %s' % backup_path)
             sys.exit()

--- a/lib/ansible/roles/snapshots/tasks/main.yml
+++ b/lib/ansible/roles/snapshots/tasks/main.yml
@@ -1,14 +1,4 @@
 ---
-- name: Install apt packages
-  apt: pkg={{ item }} state=present
-  with_items: "{{ snapshots_packages }}"
-  sudo: yes
-
-- name: Install pip packages
-  pip: name={{item}} state=present
-  with_items: "{{ snapshots_pip_packages }}"
-  sudo: yes
-
 - name: Configure backup parameters
   set_fact:
     snapshots_config:
@@ -22,13 +12,23 @@
       retention: "{{ snapshots__retention | default() }}"
       retention_lag: "{{ snapshots__retention_lag | default() }}"
   when: >
-    stage == "production" and (
-      snapshots__method is defined
-      or snapshots__credentials is defined
-      or snapshots__interval is defined
-      or snapshots__retention is defined
-      or snapshots__retention_lag is defined
-    )
+    snapshots__method is defined
+    or snapshots__credentials is defined
+    or snapshots__interval is defined
+    or snapshots__retention is defined
+    or snapshots__retention_lag is defined
+
+- name: Install apt packages
+  apt: pkg={{ item }} state=present
+  with_items: "{{ snapshots_packages }}"
+  when: snapshots_config is defined
+  sudo: yes
+
+- name: Install pip packages
+  pip: name={{item}} state=present
+  with_items: "{{ snapshots_pip_packages }}"
+  when: snapshots_config is defined
+  sudo: yes
 
 - name: Install backup script
   copy: src=backup.py dest=/usr/local/bin/snapshot-backup.py owner=deploy group=deploy mode=0755

--- a/lib/ansible/roles/snapshots/tasks/main.yml
+++ b/lib/ansible/roles/snapshots/tasks/main.yml
@@ -25,7 +25,7 @@
   sudo: yes
 
 - name: Install pip packages
-  pip: name={{item}} state=present
+  pip: name={{item}} state=latest
   with_items: "{{ snapshots_pip_packages }}"
   when: snapshots_config is defined
   sudo: yes

--- a/lib/ansible/roles/snapshots/vars/main.yml
+++ b/lib/ansible/roles/snapshots/vars/main.yml
@@ -6,3 +6,4 @@ snapshots_packages:
 snapshots_pip_packages:
   - grandfatherson
   - tabulate
+  - certifi

--- a/lib/capistrano/tasks/files.rake
+++ b/lib/capistrano/tasks/files.rake
@@ -1,32 +1,92 @@
 namespace :evolve do
   namespace :files do
-    task :prepare, :path_from, :path_to do |task, args|
-      invoke "evolve:prepare_key"
-      set :rsync_cmd, "rsync -e \"ssh -i #{fetch(:ssh_keyfile)}\" -avvru --delete --copy-links --progress #{args[:path_from]}/ #{args[:path_to]}/"
+    task :prepare, :path_from, :path_to, :skip_ssh do |task, args|
+      ssh_creds = ''
+      unless args[:skip_ssh]
+        invoke "evolve:prepare_key"
+        ssh_creds = "-e \"ssh -i #{fetch(:ssh_keyfile)}\""
+      end
+
+      set :rsync_cmd, "rsync #{ssh_creds} -avvru --delete --copy-links --progress #{args[:path_from]}/ #{args[:path_to]}/"
+    end
+
+    task :import, :source_stage, :target_stage, :source_path do |task, args|
+      source_stage = args[:source_stage].to_s
+      target_stage = args[:target_stage].to_s
+
+      # default upload paths (unless overridden via :source_path)
+      local_uploads = "#{Dir.pwd}/web/wp-content/uploads"
+      remote_uploads = "#{release_path}/web/wp-content/uploads"
+
+      # predefine some common bool checks
+      uploads_exist = false
+      local_source = source_stage == 'local'
+      local_target = target_stage == 'local'
+
+      # determine source and target upload paths, given args and stages
+      source_path = args[:source_path] ? args[:source_path] : (local_source ? local_uploads : remote_uploads)
+      target_path = local_target ? local_uploads : remote_uploads
+
+      # predefine source path existence check
+      uploads_test = "[ -d #{source_path} ]"
+
+      # test uploads locally/remotely
+      if (args[:source_path] && local_target) || (!args[:source_path] && local_source)
+        run_locally do
+          uploads_exist = test uploads_test
+        end
+      else
+        on roles(:web) do |host|
+          uploads_exist = test uploads_test
+        end
+      end
+
+      # without uploads, bail early from this task
+      unless uploads_exist
+        warn "!! No uploads to rsync from #{source_path}...skipping"
+        next
+      end
+
+      # without a source path override, wrap non-local path with "user@host:" ssh creds
+      unless args[:source_path]
+        ssh_host = ''
+        on roles(:web) do |host|
+          ssh_host = host
+        end
+        if local_source
+          target_path = "#{fetch(:user)}@#{ssh_host}:#{target_path}"
+        else
+          source_path = "#{fetch(:user)}@#{ssh_host}:#{source_path}"
+        end
+      end
+
+      # fix remote permissions before sync
+      invoke "evolve:permissions" unless local_target
+
+      # derive :skip_ssh from whether :source_path is defined
+      invoke "evolve:files:prepare", source_path, target_path, args[:source_path]
+
+      # execute rsync against the appropriate environment (control or remote)
+      if (args[:source_path] && local_target) || !args[:source_path]
+        run_locally do
+          execute fetch(:rsync_cmd)
+        end
+      else
+        on roles(:web) do |host|
+          execute fetch(:rsync_cmd)
+        end
+      end
+
+      # fix again after sync
+      invoke "evolve:permissions" unless local_target
+
     end
 
     task :down do |task|
       begin
-        raise "Cannot sync files down from local!" if fetch(:stage) == 'local'
+        raise "Cannot sync files down from local!" if fetch(:stage).to_s == 'local'
 
-        local_uploads = "#{Dir.pwd}/web/wp-content/uploads"
-        remote_uploads = "#{release_path}/web/wp-content/uploads"
-        uploads_exist = false
-
-        on roles(:web) do |host|
-          uploads_exist = test "[ -d #{remote_uploads} ]"
-        end
-
-        if uploads_exist
-          on roles(:web) do |host|
-            invoke "evolve:files:prepare", "#{fetch(:user)}@#{host}:#{remote_uploads}", local_uploads
-            run_locally do
-              execute fetch(:rsync_cmd)
-            end
-          end
-        else
-          warn "!! No remote uploads to sync...skipping"
-        end
+        invoke "evolve:files:import", fetch(:stage), 'local'
 
         success=true
       ensure
@@ -36,33 +96,10 @@ namespace :evolve do
 
     task :up do |task|
       begin
-        raise "Cannot sync files up to local!" if fetch(:stage) == 'local'
+        raise "Cannot sync files up to local!" if fetch(:stage).to_s == 'local'
 
         invoke "evolve:confirm", "You are about to overwrite \"#{fetch(:stage)}\" files!"
-
-        local_uploads = "#{Dir.pwd}/web/wp-content/uploads"
-        remote_uploads = "#{release_path}/web/wp-content/uploads"
-        uploads_exist = false
-
-        run_locally do
-          uploads_exist = test "[ -d #{local_uploads} ]"
-        end
-
-        if uploads_exist
-          invoke "evolve:permissions"
-
-          on roles(:web) do |host|
-            invoke "evolve:files:prepare", local_uploads, "#{fetch(:user)}@#{host}:#{remote_uploads}"
-            run_locally do
-              execute fetch(:rsync_cmd)
-            end
-
-          end
-
-          invoke "evolve:permissions"
-        else
-          warn "!! No local uploads to sync...skipping"
-        end
+        invoke "evolve:files:import", 'local', fetch(:stage)
 
         success=true
       ensure

--- a/lib/capistrano/tasks/server.rake
+++ b/lib/capistrano/tasks/server.rake
@@ -124,6 +124,7 @@ namespace :evolve do
         end
       end
     end
+    Rake::Task['evolve:permissions'].reenable
   end
 
   desc "Remove remote deployments"

--- a/lib/capistrano/tasks/snapshot.rake
+++ b/lib/capistrano/tasks/snapshot.rake
@@ -1,0 +1,89 @@
+namespace :evolve do
+  namespace :snapshot do
+    desc "Restore a backup to the remote"
+    task :restore do |task|
+      # need to retrieve a list of existing backups
+      # provide list and let user select one
+    end
+
+    desc "Prompt for and simulate a backup schedule"
+    task :simulate do |task|
+      # for interval and retention periods
+      units = ['hour', 'day', 'week', 'month', 'year']
+
+      # load vars from group_vars, or default values
+      require 'yaml'
+      group_vars = YAML.load_file('lib/ansible/group_vars/all')
+      group_vars['snapshots__method'] = 'local' unless group_vars.key?('snapshots__method')
+      group_vars['snapshots__credentials'] = '' unless group_vars.key?('snapshots__credentials')
+      group_vars['snapshots__container'] = "/home/deploy/backup/production.#{fetch(:domain)}" unless group_vars.key?('snapshots__container')
+      group_vars['snapshots__interval'] = '1d' unless group_vars.key?('snapshots__interval')
+      group_vars['snapshots__retention'] = {'days'=>1, 'weeks'=>1, 'months'=>1, 'years'=>1} unless group_vars.key?('snapshots__retention')
+      group_vars['snapshots__retention_lag'] = true unless group_vars.key?('snapshots__retention_lag')
+
+      # prompt for relevant values
+      require 'inquirer'
+
+      # first, prompt for and construct a snapshot interval (value + unit)
+      interval_unit = Inquirer.prompt([{
+        :name    => :interval_unit,
+        :type    => :list,
+        :message => 'By what interval of time should we take snapshots?',
+        :choices => units.map{ |s| {:name => s+'s', :value => s[0,1]} },
+        :default => group_vars['snapshots__interval'].match(/^\d+([hdwmy])$/)[1],
+      }])
+      interval_unit = interval_unit[:interval_unit]
+
+      full_unit = units.each.detect{ |s| s.start_with?(interval_unit) }
+      interval_val = Inquirer.prompt([{
+        :name     => :interval_val,
+        :type     => :input,
+        :message  => "And we'll take a snapshot every how many #{full_unit}s?",
+        :default  => group_vars['snapshots__interval'].match(/^(\d+)[hdwmy]$/)[1],
+        :validate => lambda { |s| s.match(/^\d+$/) }
+      }])
+      interval_val = interval_val[:interval_val]
+
+      group_vars['snapshots__interval'] = interval_val.to_s + interval_unit
+
+      # next, prompt for and construct retention periods
+      periods = {}
+      units.each_with_index do |unit, idx|
+        display_unit = unit.end_with?('y') ? unit[0..-2]+'ily' : unit+'ly'
+        period_val = Inquirer.prompt([{
+          :name => :period_val,
+          :type => :input,
+          :message => "Retain how many #{display_unit} backups?",
+          :default => group_vars['snapshots__retention'].fetch(unit+'s', 0).to_s,
+          :validate => lambda { |s| s.match(/^\d+$/) }
+        }])
+        periods[unit+'s'] = period_val[:period_val]
+      end
+
+      group_vars['snapshots__retention'] = periods
+
+      # finally, prompt for retention lag
+      lag_val = Inquirer.prompt([{
+        :name => :lag_val,
+        :type => :confirm,
+        :message => "Should backup retention lag one #{full_unit} behind?",
+        :default => group_vars['snapshots__retention_lag']
+      }])
+
+      group_vars['snapshots__retention_lag'] = lag_val[:lag_val]
+
+      # invoke backup script with --simulate and group_vars matching /^snapshots__/
+      require 'json'
+      config = Hash[group_vars.select{|key, value| key.match(/^snapshots__/) }.map{|key, val| [key.match(/^snapshots__(.+)$/)[1] , val] } ]
+      config['stage'] = fetch(:stage)
+      config['domain'] = fetch(:domain)
+      config['dbname'] = group_vars['mysql']['name']
+      config['releasepath'] = fetch(:deploy_to)
+
+      on roles(:web) do |host|
+        execute "/usr/local/bin/snapshot-backup.py", "-vvv", "-s", "-c", "'#{JSON.dump(config)}'"
+      end
+    end
+
+  end
+end

--- a/lib/capistrano/tasks/util.rake
+++ b/lib/capistrano/tasks/util.rake
@@ -61,6 +61,11 @@ WARN
     end
   end
 
+  task :retrieve_groupvars do |task|
+    require 'yaml'
+    set :group_vars, YAML.load_file('lib/ansible/group_vars/all')
+  end
+
   task :log, :success, :message do |task, args|
     require 'etc'
     require 'socket'

--- a/lib/yeoman/templates/Gemfile
+++ b/lib/yeoman/templates/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gem 'capistrano', '~> 3.2.1', require: false, group: :development
 gem 'colored', '~> 1.2', require: false, group: :development
 gem 'launchy', '~> 2.4', require: false, group: :development
+gem 'inquirer.rb', '~> 0.0.3', require: false, group: :development

--- a/lib/yeoman/templates/Gemfile.lock
+++ b/lib/yeoman/templates/Gemfile.lock
@@ -9,11 +9,15 @@ GEM
     colored (1.2)
     colorize (0.7.3)
     i18n (0.6.9)
+    inquirer.rb (0.0.9)
+      rainbow (~> 2.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
+    rainbow (2.2.2)
+      rake
     rake (10.3.2)
     sshkit (1.5.1)
       colorize
@@ -26,4 +30,5 @@ PLATFORMS
 DEPENDENCIES
   capistrano (~> 3.2.1)
   colored (~> 1.2)
+  inquirer.rb (~> 0.0.3)
   launchy (~> 2.4)


### PR DESCRIPTION
Several improvements made to the backup script itself:

* Resolved some warnings regarding development versions and ssl cert checking
* Added `--list`, `--retrieve` and `--force` modes
* Revised `mysqldump` to match the output format of wp-cli's `db export` and our cap task's `:db:backup`
* Resolved string casting issue for retention periods

Also a couple provisioning changes:

* backup script (and any apt/pip dependencies) will be installed _on all stages_
* added pip install of certifi, for ssl cert updates
* the backup _cron job_ is still installed only on production

As well, I've refactored some of the cap tasks:

* Gemfiles have been updated, with an additional gem dependancy
* resolved some broken stage-specific checks (was comparing symbols as strings)
* database importing and file rsyncing abstracted out into `:import` tasks respectively
* added snapshot-specific tasks (with docs!)
  * `:snapshot:simulate` easily simulates backup history for the past year, given a chosen config
  * `:snapshot:force` allows on-demand backup creation, outside of snapshot interval and without any retention checks
  * `:snapshot:restore` allows easily restoring existing snapshots to local or prod
