### PR TITLE
PECL failure on already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You will need:
   * [Hostmanager for Vagrant](https://github.com/smdahlen/vagrant-hostmanager#installation)
 * [npm](https://docs.npmjs.com/getting-started/installing-node)
 * [Bundler](http://bundler.io/)
-* [Ansible](http://docs.ansible.com/intro_installation.html) 1.6+
+* [Ansible](http://docs.ansible.com/intro_installation.html) 2.0+
 * [sshpass](https://gist.github.com/arunoda/7790979)
 
 You can then use npm to install Bower and the Yeoman generator:

--- a/lib/ansible/roles/php/tasks/php5-install.yml
+++ b/lib/ansible/roles/php/tasks/php5-install.yml
@@ -5,7 +5,7 @@
   sudo:           yes
 
 - name:           Install PECL packages
-  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php5_mods_path }}/{{ item if item is string else item.name }}.ini
+  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates="{{ php5_lib_path }}/*/{{ item if item is string else item.name }}.so"
   with_items:     "{{ pecl5_packages }}"
   sudo:           yes
 

--- a/lib/ansible/roles/php/tasks/php7-install.yml
+++ b/lib/ansible/roles/php/tasks/php7-install.yml
@@ -9,7 +9,7 @@
   sudo:           yes
 
 - name:           Install PECL packages
-  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates={{ php7_mods_path }}/{{ item if item is string else item.name }}.ini
+  command:        pecl install {{ item if item is string else item.name + '-' + item.version }} creates="{{ php7_lib_path }}/*/{{ item if item is string else item.name }}.so"
   with_items:     "{{ pecl7_packages }}"
   sudo:           yes
 

--- a/lib/ansible/roles/php/vars/main.yml
+++ b/lib/ansible/roles/php/vars/main.yml
@@ -29,5 +29,8 @@ php7_packages:
 php5_conf_path: '/etc/php5'
 php7_conf_path: '/etc/php/7.1'
 
+php5_lib_path: '/usr/lib/php5'
+php7_lib_path: '/usr/lib/php'
+
 php5_mods_path: '{{ php5_conf_path }}/mods-available'
 php7_mods_path: '{{ php7_conf_path }}/mods-available'


### PR DESCRIPTION
This should not cause a fail of the entire provision...

```
TASK: [php | Install PECL packages] ******************************************* 
failed: [production.example.org] => (item={'version': '0.1.0', 'name': 'scream'}) => {"changed": true, "cmd": ["pecl", "install", "scream-0.1.0"], "delta": "0:00:00.359906", "end": "2016-08-10 17:25:56.536163", "item": {"name": "scream", "version": "0.1.0"}, "rc": 1, "start": "2016-08-10 17:25:56.176257"}
stdout: pecl/scream is already installed and is the same as the released version 0.1.0
install failed

FATAL: all hosts have already failed -- aborting
```
