### PR TITLE
PHP upgrade/downgrade bug fixes

### DIFF
--- a/lib/ansible/roles/mysql/vars/main.yml
+++ b/lib/ansible/roles/mysql/vars/main.yml
@@ -5,5 +5,4 @@ mysql_packages:
   - libapache2-mod-auth-mysql
   - mysql-server-5.6
   - mysql-server-core-5.6
-  - php5-mysql
   - python-mysqldb

--- a/lib/ansible/roles/newrelic/tasks/main.yml
+++ b/lib/ansible/roles/newrelic/tasks/main.yml
@@ -7,6 +7,12 @@
   apt_repository: repo='deb http://apt.newrelic.com/debian/ newrelic non-free' state=present
   sudo:           yes
 
+# if upgrading to 7 or downgrading to 5, remove & purge existing agent, let it install again with new php
+- name:           Remove and purge existing agent (when upgrading/downgrading PHP)
+  apt:            name=newrelic-php5 state=absent purge=yes
+  when:           php_downgrade == true or php_upgrade == true
+  sudo:           yes
+
 - name:           Install PHP agent and sys monitor
   apt:            name={{ item }} state=latest update_cache=yes
   sudo:           yes

--- a/lib/ansible/roles/php/tasks/main.yml
+++ b/lib/ansible/roles/php/tasks/main.yml
@@ -13,14 +13,22 @@
 
 - debug: msg={{ php_major_version }}
 
+- set_fact:
+    php_upgrade: '{{ php_major_version.stdout == "5" and php__version_7 == true }}'
+
+- set_fact:
+    php_downgrade: '{{ php_major_version.stdout == "7" and php__version_7 == false }}'
+
+- debug: msg='{{ "Upgrading" if php_upgrade else "Downgrading" if php_downgrade else "No change in" }} PHP major version'
+
 # remove php7 as necessary before we install php5
 - include: php7-uninstall.yml
-  when: php_major_version.stdout == "7" and php__version_7 == false
+  when: php_downgrade
   sudo: yes
 
 # remove php5 as necessary before we install php7
 - include: php5-uninstall.yml
-  when: php_major_version.stdout == "5" and php__version_7 == true
+  when: php_upgrade
   sudo: yes
 
 - include: php5-install.yml

--- a/lib/ansible/roles/php/vars/main.yml
+++ b/lib/ansible/roles/php/vars/main.yml
@@ -13,6 +13,7 @@ php5_packages:
   - php5-curl
   - php5-gd
   - php5-mcrypt
+  - php5-mysql
   - php5-dev
 
 php7_packages:
@@ -24,6 +25,13 @@ php7_packages:
   - php7.1-curl
   - php7.1-gd
   - php7.1-mcrypt
+  - php7.1-mysql
+  - php7.1-mbstring
+  - php7.1-bcmath
+  - php7.1-bz2
+  - php7.1-dba
+  - php7.1-soap
+  - php7.1-zip
   - php7.1-dev
 
 php5_conf_path: '/etc/php5'


### PR DESCRIPTION
When upgrading an existing and already provisioned server to php7 (or downgrading back to php5), we:

* ensure the appropriate mysql package is installed for the given php (#171)
* ensure all packages bundled with php5 are installed for php7 (#172)
* ensure newrelic agent is removed, purged, and reinstalled after php uninstall/reinstall (#173)
