### PR TITLE
Per-project apt package installation

### DIFF
--- a/lib/ansible/roles/cleanup/tasks/main.yml
+++ b/lib/ansible/roles/cleanup/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- set_fact:
+    custom__packages: []
+  when: custom__packages is undefined
+
+- name:         Install custom packages
+  apt:          pkg={{ item }} state=present
+  with_items:   "{{ custom__packages }}"
+  sudo:         yes
+
 - name:         Ensure logrotate runs hourly
   command:      mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
   args:

--- a/lib/yeoman/templates/lib/ansible/group_vars/all
+++ b/lib/yeoman/templates/lib/ansible/group_vars/all
@@ -12,6 +12,9 @@ mysql:
   password:     <%= props.DB_PASSWORD %>
   host:         <%= props.DB_HOST %>
 
+# custom__packages:
+#   - "extra-apt-package"
+
 <% if (props.datadog) { %>datadog_api_key: '<%= props.datadog %>'<% } %>
 
 # php__memory_limit:


### PR DESCRIPTION
By default, this will put a commented out variable in your group_vars:

```yml
# custom__packages:
#   - "extra-apt-package"
```

Should your project need extra apt packages installed, just uncomment and put them in a list:

```yml
custom__packages:
  - "php7.1-cgi"
  - "php7.1-odbc"
  - "php7.1-snmp"
  - "php7.1-soap"
```

On the next provision, these will be installed during cleanup (so any standard prereqs, like php 7.1 itself, would already be installed beforehand)

/cc @jasoncomes